### PR TITLE
Setup Docker container and Nix Flake

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "Ziofa Builder",
+  "image": "ghcr.io/fhilgers/ziofa-builder:latest",
+  "features": {},
+  "remoteUser": "worker",
+  "updateRemoteUserUID": false
+}

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ bin/
 
 # Direnv
 /.direnv
+
+target

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ bin/
 
 # MacOS
 .DS_Store
+
+# Direnv
+/.direnv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# Fabulous Project (AMOS SS 20xx)
-Something something something
+# Zero Instrumentation Observability for Android (AMOS WS 2024)
+
+
+## Building
+
+### [Nix](https://nixos.org/download/)
+
+The easiest way to get all dependencies is to use the provided development shell in `flake.nix`.
+You can use a tool like [`direnv`](https://github.com/direnv/direnv) to automatically load the environment for this repository.
+
+The shell will setup:
+
+- The rust nightly toolchain (nightly is required currently for ebpf because of the unstable [`build-std`](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) feature)
+- The [`bpf-linker`](https://github.com/aya-rs/bpf-linker/)
+- The Android SDK and NDK
+- The [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk) package for compiling for rust for android
+- The [`protobuf`](https://protobuf.dev/) programs for generating grpc server and client code
+
+### [OCI Container](https://opencontainers.org/)
+
+We use the same input that go into the development shell for building a layered docker image.
+This image is used for the ci, so it supports building the project as well, however you graphical applications like the android emulator require custom setups depending on your OS.
+
+The container image is built via nix and can be automatically uploaded to the registry via `nix run .#dockerBuilder.copyToRegistry`.
+It is currently hosted in the github registry under `ghcr.io/fhilgers/ziofa-builder`.
+
+For a working emulator inside the docker image, you will need some form of X11 forwarding.
+Installing nix and using the development shell is the recommended approach for development.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729413321,
+        "narHash": "sha256-I4tuhRpZFa6Fu6dcH9Dlo5LlH17peT79vx1y1SpeKt0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1997e4aa514312c1af7e2bda7fad1644e778ff26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -100,6 +100,45 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729339656,
+        "narHash": "sha256-smV7HQ/OqZeRguQxNjsb3uQDwm0p6zKDbSDbPCav/oY=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "cc96df7c3747c61c584d757cfc083922b4f4b33e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1729413321,
@@ -133,6 +172,7 @@
         "android-nixpkgs": "android-nixpkgs",
         "fenix": "fenix",
         "flake-parts": "flake-parts",
+        "nix2container": "nix2container",
         "nixpkgs": "nixpkgs"
       }
     },
@@ -154,6 +194,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -64,6 +64,24 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -98,10 +116,23 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      }
+    },
     "root": {
       "inputs": {
         "android-nixpkgs": "android-nixpkgs",
         "fenix": "fenix",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,48 @@
 {
   "nodes": {
+    "android-nixpkgs": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729714795,
+        "narHash": "sha256-ZmSPkEAJ7H7WSDN9fC9OKtEaZ003H+Dr/WVVKStQ+/I=",
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "rev": "6bf6c34925f86d31f956a5bebfe37716626cf410",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "android-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -21,6 +64,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1729413321,
@@ -39,6 +100,7 @@
     },
     "root": {
       "inputs": {
+        "android-nixpkgs": "android-nixpkgs",
         "fenix": "fenix",
         "nixpkgs": "nixpkgs"
       }
@@ -57,6 +119,21 @@
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1729751566,
+        "narHash": "sha256-99u/hrgBdi8bxSXZc9ZbNkR5EL1htrkbd3lsbKzS60g=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f32a2d484091a6dc98220b1f4a2c2d60b7c97c64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1729413321,
@@ -18,7 +39,25 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729715509,
+        "narHash": "sha256-jUDN4e1kObbksb4sc+57NEeujBEDRdLCOu9wiE3RZdM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "40492e15d49b89cf409e2c5536444131fac49429",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,39 @@
   description = "A very basic flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  };
-
-  outputs = { self, nixpkgs }: let
-    system = "x86_64-linux";
-    pkgs = import nixpkgs { inherit system; };
-  in {
-    devShells.${system}.default = pkgs.mkShell {
+    nixpkgs = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
+
+  outputs = { self, nixpkgs, fenix }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs { inherit system; };
+      fenixPkgs = fenix.packages.${system};
+
+      rust = {
+        # https://rust-lang.github.io/rustup-components-history/
+        # We need nightly for aya to build ebpf programs
+        nightlyToolchain = fenixPkgs.combine [
+          fenixPkgs.latest.toolchain
+          fenixPkgs.targets.x86_64-linux-android.latest.rust-std
+        ];
+      };
+
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          rust.nightlyToolchain
+          protobuf
+          bpf-linker
+        ];
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,11 @@
             ];
 
             rustPkgs = with pkgs.fenix; [
-              (combine [ latest.toolchain targets.x86_64-linux-android.latest.rust-std ])
+              (combine [
+                latest.toolchain
+                targets.x86_64-linux-android.latest.rust-std
+                targets.aarch64-linux-android.latest.rust-std
+              ])
             ];
 
             miscPkgs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -13,48 +13,50 @@
       url = "github:tadfisher/android-nixpkgs";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+    };
   };
 
-  outputs = { self, nixpkgs, fenix, android-nixpkgs }:
-    let
-      system = "x86_64-linux";
-
-      pkgs = import nixpkgs { inherit system; };
-      fenixPkgs = fenix.packages.${system};
-      mkAndroidSdk = android-nixpkgs.sdk.${system};
-
-      androidSdk = {
-        sdk = mkAndroidSdk (sdkPkgs: with sdkPkgs; [
-          cmdline-tools-latest
-          ndk-28-0-12433566
-          build-tools-35-0-0
-          platform-tools
-          platforms-android-35
-          emulator
-          system-images-android-35-default-x86-64
-        ]);
-      };
-
-      rust = {
-        # https://rust-lang.github.io/rustup-components-history/
-        # We need nightly for aya to build ebpf programs
-        nightlyToolchain = fenixPkgs.combine [
-          fenixPkgs.latest.toolchain
-          fenixPkgs.targets.x86_64-linux-android.latest.rust-std
-        ];
-      };
-
-    in
-    {
-      devShells.${system}.default = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          rust.nightlyToolchain
-          protobuf
-          bpf-linker
-          androidSdk.sdk
-          cargo-ndk
-          python3 
-        ];
-      };
+  outputs = inputs@{ self, nixpkgs, fenix, android-nixpkgs, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        ./nix/overlay-module.nix
+      ];
+      systems = nixpkgs.lib.systems.flakeExposed;
+      perSystem = { config, pkgs, system, ... }:
+        let
+          androidSdk = {
+            sdk = pkgs.androidSdk (sdkPkgs: with sdkPkgs; [
+              cmdline-tools-latest
+              ndk-28-0-12433566
+              build-tools-35-0-0
+              platform-tools
+              platforms-android-35
+              emulator
+              system-images-android-35-default-x86-64
+            ]);
+          };
+          rust = {
+            # https://rust-lang.github.io/rustup-components-history/
+            # We need nightly for aya to build ebpf programs
+            nightlyToolchain = pkgs.fenix.combine (with pkgs.fenix; [
+              latest.toolchain
+              targets.x86_64-linux-android.latest.rust-std
+            ]);
+          };
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              rust.nightlyToolchain
+              protobuf
+              bpf-linker
+              androidSdk.sdk
+              cargo-ndk
+              python3
+            ];
+          };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,13 @@
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
     };
+    nix2container = {
+      url = "github:nlewo/nix2container";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = inputs@{ self, nixpkgs, fenix, android-nixpkgs, flake-parts, ... }:
+  outputs = inputs@{ self, nixpkgs, fenix, android-nixpkgs, nix2container, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         ./nix/overlay-module.nix
@@ -26,8 +30,31 @@
       systems = nixpkgs.lib.systems.flakeExposed;
       perSystem = { config, pkgs, system, ... }:
         let
-          androidSdk = {
-            sdk = pkgs.androidSdk (sdkPkgs: with sdkPkgs; [
+          packageGroups = {
+
+            base = with pkgs; [
+              git
+              python3
+              gcc
+              gnugrep
+              gnused
+              gawk
+              findutils
+              iproute2
+              cacert
+              gcc.cc.lib
+              glibc.out
+              coreutils
+              which
+              bash
+            ];
+
+            sdkBase = with pkgs; [
+              ncurses5
+              openjdk
+            ];
+
+            sdkPkgs = with pkgs.androidSdkPackages; [
               cmdline-tools-latest
               ndk-28-0-12433566
               build-tools-35-0-0
@@ -35,27 +62,98 @@
               platforms-android-35
               emulator
               system-images-android-35-default-x86-64
-            ]);
-          };
-          rust = {
-            # https://rust-lang.github.io/rustup-components-history/
-            # We need nightly for aya to build ebpf programs
-            nightlyToolchain = pkgs.fenix.combine (with pkgs.fenix; [
-              latest.toolchain
-              targets.x86_64-linux-android.latest.rust-std
-            ]);
-          };
-        in
-        {
-          devShells.default = pkgs.mkShell {
-            buildInputs = with pkgs; [
-              rust.nightlyToolchain
+            ];
+
+            rustPkgs = with pkgs.fenix; [
+              (combine [ latest.toolchain targets.x86_64-linux-android.latest.rust-std ])
+            ];
+
+            miscPkgs = with pkgs; [
+              cargo-ndk
               protobuf
               bpf-linker
-              androidSdk.sdk
-              cargo-ndk
-              python3
             ];
+
+            combined =
+              packageGroups.base ++
+              packageGroups.sdkBase ++
+              [ (pkgs.androidSdk (_: packageGroups.sdkPkgs)) ] ++
+              packageGroups.rustPkgs ++
+              packageGroups.miscPkgs;
+          };
+
+          builderBase = pkgs.n2c.buildImage (with pkgs; {
+            name = "ghcr.io/fhilgers/ziofa-builder-base";
+            tag = "latest";
+            copyToRoot = [
+              (buildEnv {
+                name = "root";
+                pathsToLink = [ "/bin" "/lib64" "/lib" "/share" "/etc" ];
+                paths = packageGroups.combined;
+              })
+            ];
+            layers =
+              let
+                mL = deps: layers: n2c.buildLayer { deps = deps; layers = layers; };
+                baseLayer = mL packageGroups.base [ ];
+                miscLayer = mL packageGroups.miscPkgs [ baseLayer ];
+                rustLayer = mL packageGroups.rustPkgs [ baseLayer ];
+                sdkBaseLayer = mL packageGroups.sdkBase [ baseLayer ];
+                sdkLayers = map (sdkPkg: mL [ sdkPkg ] [ sdkBaseLayer baseLayer ]) packageGroups.sdkPkgs;
+              in
+              [
+                baseLayer
+                miscLayer
+                rustLayer
+                sdkBaseLayer
+              ] ++ sdkLayers;
+          });
+
+          dockerHelpers = import ./nix/docker-helpers.nix { pkgs = pkgs; };
+          inherit (dockerHelpers) mkWorker mkDoas mkDoasPerms mkWorkerPerms mkTmp mkHome mkEnv;
+
+          builder = pkgs.n2c.buildImage {
+            name = "ghcr.io/fhilgers/ziofa-builder";
+            tag = "latest";
+            fromImage = builderBase;
+            copyToRoot = [
+              mkTmp
+              mkEnv
+              mkHome
+              mkWorker
+              mkDoas
+
+              pkgs.bashInteractive
+              pkgs.bashConfigs
+            ];
+            perms = [
+              (mkWorkerPerms mkTmp "/tmp")
+              (mkWorkerPerms mkHome "/home/worker")
+              (mkDoasPerms mkDoas "/sbin/doas")
+            ];
+            config = {
+              entrypoint = [ "/bin/bash" ];
+              User = "worker";
+              WorkingDir = "/home/worker";
+              Env = [
+                "PATH=/bin:/sbin:/usr/bin:/usr/sbin"
+                "HOME=/home/worker"
+                "LD_LIBRARY_PATH=/lib:/lib64"
+                "ANDROID_HOME=/share/android-sdk" # deprecated but android-studio needs it
+                "ANDROID_SDK_ROOT=/share/android-sdk"
+                "ANDROID_NDK_HOME=/share/android-sdk/ndk"
+              ];
+            };
+          };
+
+        in
+        {
+          devShells = {
+            default = pkgs.mkShell { packages = packageGroups.combined; };
+          };
+          packages = {
+            dockerBuilderBase = builderBase;
+            dockerBuilder = builder;
           };
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,13 @@
               mkWorker
               mkDoas
 
+              # github actions
+              # TODO: move them to another layer
+              pkgs.nodejs
+              pkgs.gnutar
+              pkgs.zstd
+              pkgs.gzip
+
               pkgs.bashInteractive
               pkgs.bashConfigs
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -9,14 +9,31 @@
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    android-nixpkgs = {
+      url = "github:tadfisher/android-nixpkgs";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, fenix }:
+  outputs = { self, nixpkgs, fenix, android-nixpkgs }:
     let
       system = "x86_64-linux";
 
       pkgs = import nixpkgs { inherit system; };
       fenixPkgs = fenix.packages.${system};
+      mkAndroidSdk = android-nixpkgs.sdk.${system};
+
+      androidSdk = {
+        sdk = mkAndroidSdk (sdkPkgs: with sdkPkgs; [
+          cmdline-tools-latest
+          ndk-28-0-12433566
+          build-tools-35-0-0
+          platform-tools
+          platforms-android-35
+          emulator
+          system-images-android-35-default-x86-64
+        ]);
+      };
 
       rust = {
         # https://rust-lang.github.io/rustup-components-history/
@@ -34,6 +51,9 @@
           rust.nightlyToolchain
           protobuf
           bpf-linker
+          androidSdk.sdk
+          cargo-ndk
+          python3 
         ];
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
               platform-tools
               platforms-android-35
               emulator
-              system-images-android-35-default-x86-64
+              system-images-android-33-default-x86-64
             ];
 
             rustPkgs = with pkgs.fenix; [

--- a/nix/bash-configs.nix
+++ b/nix/bash-configs.nix
@@ -1,0 +1,69 @@
+# Adapted from https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/programs/bash
+
+{ pkgs, ... }:
+let
+
+  interactiveShellInit = ''
+    	  # Provide a nice prompt if the terminal supports it.
+        if [ "$TERM" != "dumb" ] || [ -n "$INSIDE_EMACS" ]; then
+          PROMPT_COLOR="1;31m"
+          ((UID)) && PROMPT_COLOR="1;32m"
+          if [ -n "$INSIDE_EMACS" ]; then
+            # Emacs term mode doesn't support xterm title escape sequence (\e]0;)
+            PS1="\n\[\033[$PROMPT_COLOR\][\u@\h:\w]\\$\[\033[0m\] "
+          else
+            PS1="\n\[\033[$PROMPT_COLOR\][\[\e]0;\u@\h: \w\a\]\u@\h:\w]\\$\[\033[0m\] "
+          fi
+          if test "$TERM" = "xterm"; then
+            PS1="\[\033]2;\h:\u:\w\007\]$PS1"
+          fi
+        fi
+    
+        # Completion
+    	  if shopt -q progcomp &>/dev/null; then
+          . "${pkgs.bash-completion}/etc/profile.d/bash_completion.sh"
+          nullglobStatus=$(shopt -p nullglob)
+          shopt -s nullglob
+          for m in "/etc/bash_completion.d/"*; do
+            . "$m"
+          done
+          eval "$nullglobStatus"
+          unset nullglobStatus p m
+        fi
+    	'';
+
+  profile = pkgs.writeTextDir "etc/profile" ''
+    	  if [ -n "$__ETC_PROFILE_SOURCED" ]; then return; fi
+    
+        __ETC_PROFILE_SOURCED=1
+    		export __ETC_PROFILE_DONE=1
+
+    		if [ -n "''${BASH_VERSION:-}" ]; then
+    		    . /etc/bashrc
+    		fi
+    	'';
+
+  bashrc = pkgs.writeTextDir "etc/bashrc" ''
+    	  if [ -n "$__ETC_BASHRC_SOURCED" ] || [ -n "$NOSYSBASHRC" ]; then return; fi
+        __ETC_BASHRC_SOURCED=1
+
+        # If the profile was not loaded in a parent process, source
+        # it.  But otherwise don't do it because we don't want to
+        # clobber overridden values of $PATH, etc.
+        if [ -z "$__ETC_PROFILE_DONE" ]; then
+            . /etc/profile
+        fi
+
+    		if [ -n "$PS1" ]; then
+          ${interactiveShellInit}
+        fi
+    	'';
+
+in
+pkgs.symlinkJoin {
+  name = "interactive-bash";
+  paths = [
+    profile
+    bashrc
+  ];
+}

--- a/nix/docker-helpers.nix
+++ b/nix/docker-helpers.nix
@@ -1,0 +1,65 @@
+{ pkgs, ... }:
+{
+  mkWorker =
+    let
+      user = "worker";
+      group = "worker";
+      uid = "1000";
+      gid = "1000";
+    in
+    (pkgs.runCommand "mkUser" { } ''
+      mkdir -p $out/etc
+      echo "${user}:x:${uid}:${gid}::" > $out/etc/passwd
+      echo "${user}:!x:::::::" > $out/etc/shadow
+      echo "root:x:0:0::" >> $out/etc/passwd
+      echo "root:!x:::::::" >> $out/etc/shadow
+
+      echo "${group}:x:${gid}:" > $out/etc/group
+      echo "${group}:x::" > $out/etc/gshadow
+      echo "root:x:0:" >> $out/etc/group
+      echo "root:x::" >> $out/etc/gshadow
+
+      cat <<EOF > $out/etc/doas.conf
+      permit nopass worker
+      EOF
+    '');
+  mkHome = pkgs.stdenv.mkDerivation {
+    name = "setup-home";
+    buildCommand = "mkdir -p $out/home/worker";
+  };
+  mkTmp = pkgs.stdenv.mkDerivation {
+    name = "setup-tmp";
+    buildCommand = "mkdir -p $out/tmp";
+  };
+  mkEnv = pkgs.stdenv.mkDerivation {
+    name = "setup-env";
+    buildCommand = ''
+      mkdir -p $out/usr/bin
+      ln -s ${pkgs.coreutils}/bin/env $out/usr/bin/env
+    '';
+  };
+  mkWorkerPerms = path: regex: {
+    inherit path regex;
+    mode = "0744";
+    uid = 1000;
+    gid = 1000;
+    uname = "worker";
+    gname = "worker";
+  };
+  mkDoasPerms = path: regex: ({
+    inherit path regex;
+    mode = "4755";
+    uid = 0;
+    gid = 0;
+    uname = "root";
+    gname = "root";
+  });
+
+  mkDoas = pkgs.stdenv.mkDerivation {
+    name = "doas";
+    buildCommand = ''
+      mkdir -p $out/sbin
+      cp -L ${pkgs.doas.override { withPAM = false; }}/bin/doas $out/sbin/
+    '';
+  };
+}

--- a/nix/overlay-module.nix
+++ b/nix/overlay-module.nix
@@ -1,0 +1,13 @@
+# This module takes the fenix and android-nixpkgs overlays and applies them to
+# the nixpkgs provided by the flake.
+({ self, inputs, ... }: {
+  perSystem = { system, ... }: {
+    _module.args.pkgs = import self.inputs.nixpkgs {
+      inherit system;
+      overlays = [
+        self.inputs.fenix.overlays.default
+        self.inputs.android-nixpkgs.overlays.default
+      ];
+    };
+  };
+})

--- a/nix/overlay-module.nix
+++ b/nix/overlay-module.nix
@@ -7,6 +7,8 @@
       overlays = [
         self.inputs.fenix.overlays.default
         self.inputs.android-nixpkgs.overlays.default
+        (prev: super: { n2c = inputs.nix2container.packages.${system}.nix2container; })
+        (prev: super: { bashConfigs = import ./bash-configs.nix { pkgs = prev; }; })
       ];
     };
   };


### PR DESCRIPTION
The docker image is currently under `ghcr.io/fhilgers/ziofa-builder`. We should look into whether we can host it under the project namespace.

You can now pull the docker image: `docker pull ghcr.io/fhilgers/ziofa-builder:latest`.

Closes #11.