### PR TITLE
Fix broken sbom generation

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.org.cyclonedx.bom)
 }
 
 android {
@@ -92,4 +93,16 @@ dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.compose)
     testImplementation(libs.koin.test)
+}
+
+tasks.cyclonedxBom {
+    setIncludeConfigs(listOf("runtimeClasspath"))
+    setSchemaVersion("1.5")
+    setProjectType("application")
+    setDestination(project.file("build/reports"))
+    setOutputName("bom")
+    setOutputFormat("json")
+    setIncludeBomSerialNumber(false)
+    setIncludeLicenseText(true)
+    setIncludeMetadataResolution(true)
 }

--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -9,7 +9,7 @@ import com.android.utils.TraceUtils.simpleId
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.org.cyclonedx.bom) apply true
+    alias(libs.plugins.org.cyclonedx.bom) apply false
     alias(libs.plugins.com.github.benmanes.versions) apply true
     alias(libs.plugins.nl.littlerobots.versioncatalogueupdate) apply true
     alias(libs.plugins.compose.compiler) apply false
@@ -38,18 +38,6 @@ tasks.dependencyUpdates.configure {
     rejectVersionIf {
         isNonStable(this.candidate.version)
     }
-}
-
-tasks.cyclonedxBom {
-    setIncludeConfigs(listOf("releaseRuntimeClasspath"))
-    setProjectType("application")
-    setSchemaVersion("1.5")
-    setDestination(project.file("build/reports"))
-    setOutputName("bom")
-    setOutputFormat("json")
-    setIncludeBomSerialNumber(false)
-    setIncludeLicenseText(true)
-    setIncludeMetadataResolution(true)
 }
 
 tasks.register("combinedFormat"){

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.android.utils.TraceUtils.simpleId
 
 // SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 

--- a/frontend/client/build.gradle.kts
+++ b/frontend/client/build.gradle.kts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
+// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 

--- a/frontend/client/build.gradle.kts
+++ b/frontend/client/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.rust.android)
+    alias(libs.plugins.org.cyclonedx.bom)
 }
 
 val rustDir = rootProject.file("../rust")
@@ -86,6 +87,17 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+}
+
+tasks.cyclonedxBom {
+    setSchemaVersion("1.5")
+    setIncludeConfigs(listOf("runtimeClasspath"))
+    setOutputName("bom")
+    setOutputFormat("json")
+    setDestination(project.file("build/reports"))
+    setIncludeBomSerialNumber(false)
+    setIncludeLicenseText(true)
+    setIncludeMetadataResolution(true)
 }
 
 afterEvaluate {

--- a/utils/generate_sbom.py
+++ b/utils/generate_sbom.py
@@ -45,6 +45,11 @@ def generate_kotlin_sbom(path: Path):
 
 
 def generate_nix_sbom():
+    print(("Generating SBOM for nix.\n\n"
+        "Running this script the first time can take a very long time and"
+        " will download a few GBs of data. You won't get any output until the"
+        " generation has been finished.\n"
+    ))
     result = subprocess.run(
         ["nix", "build", ".#toolsSbom", "-o", sub_bom_file_name + ".json"],
         capture_output=True,
@@ -56,7 +61,7 @@ def generate_nix_sbom():
         print(f"Error generating SBOM for nix: {result.stderr}")
         return None
 
-    print(f"Generated SBOM for nix")
+    print(f"Generated SBOM for nix.\n")
 
     return
 
@@ -97,6 +102,7 @@ def generate_sboms(path_for_recursive: list[Tuple[Path, bool]]) -> list[Path]:
     print("Generating SBOMs for:")
     for _, path in sbom_able_projects:
         print(" -{}".format(str(path)))
+    print()
 
     return list(filter(lambda x: x, map(lambda x: x[0](x[1]), sbom_able_projects)))
 
@@ -115,9 +121,6 @@ def merge_sboms(rel_sbom_files):
         return None
 
 def main():
-    print("        START")
-    print(" _______________________")
-
     # traverse back to base project folder
     base_dir = Path(__file__).resolve().parent.parent
 
@@ -146,8 +149,7 @@ def main():
         except FileNotFoundError:
             pass
 
-    print(" _______________________")
-    print("        DONE")
+    print("\nDone generating and merging the SBOMs. The final file is located at the root of the project: \"" + output_file_name + ".json\"")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The kotlin sbom generation got split up into its subfolders as those are of different types.

I improved the sbom generation scripts output a little bit to provide a warning about it taking ages the first time it is being run.

Closes #55 