### PR TITLE
feat: navbar with 3 tabs + topbar + navhost

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -94,6 +94,8 @@ dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.compose)
     testImplementation(libs.koin.test)
+    implementation(libs.jackwharton.timber)
+    implementation(libs.androidx.navigation.compose)
 }
 
 tasks.cyclonedxBom {

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/MainActivity.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/MainActivity.kt
@@ -8,90 +8,15 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import de.amosproj3.ziofa.client.Client
-import de.amosproj3.ziofa.client.ClientFactory
+import de.amosproj3.ziofa.ui.ZIOFAApp
 import de.amosproj3.ziofa.ui.theme.ZIOFATheme
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
-import org.koin.android.ext.android.inject
 import org.koin.androidx.compose.KoinAndroidContext
 
 class MainActivity : ComponentActivity() {
 
-    private val clientFactory: ClientFactory by inject()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContent {
-            ZIOFATheme {
-                KoinAndroidContext {
-                    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                        Counter(clientFactory, modifier = Modifier.padding(innerPadding))
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun Counter(clientFactory: ClientFactory, modifier: Modifier = Modifier) {
-    var client by remember { mutableStateOf<Client?>(null) }
-    var waiting by remember { mutableStateOf(false) }
-    var error by remember { mutableStateOf<String?>(null) }
-    val scope = rememberCoroutineScope()
-    var maybeCount by remember { mutableStateOf(0u) }
-
-    LaunchedEffect(client) {
-        client?.loadProgram("example")
-        client?.serverCount?.collect { maybeCount = it }
-    }
-
-    Box(contentAlignment = Alignment.Center, modifier = modifier.fillMaxSize()) {
-        if (client != null) {
-            Text("$maybeCount")
-        } else {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Button(
-                    onClick = {
-                        waiting = true
-                        error = null
-                        scope.launch {
-                            try {
-                                client = clientFactory.connect(scope, "http://[::1]:50051")
-                            } catch (e: Exception) {
-                                error = e.message
-                            }
-                            waiting = false
-                        }
-                    },
-                    enabled = !waiting,
-                ) {
-                    Text("Connect")
-                }
-                error?.let { Text(it, style = LocalTextStyle.current.copy(color = Color.Red)) }
-            }
-        }
+        setContent { ZIOFATheme { KoinAndroidContext { ZIOFAApp() } } }
     }
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ZIOFAApplication.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ZIOFAApplication.kt
@@ -16,10 +16,7 @@ import timber.log.Timber
 
 class ZIOFAApplication : Application() {
 
-    val appModule = module {
-        // TODO add declarations here
-        singleOf<ClientFactory>(::RustClientFactory)
-    }
+    val appModule = module { singleOf<ClientFactory>(::RustClientFactory) }
 
     override fun onCreate() {
         super.onCreate()

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ZIOFAApplication.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ZIOFAApplication.kt
@@ -12,6 +12,7 @@ import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+import timber.log.Timber
 
 class ZIOFAApplication : Application() {
 
@@ -22,6 +23,7 @@ class ZIOFAApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        Timber.plant(Timber.DebugTree()) // start Timber logging
 
         startKoin {
             androidLogger()

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui
 
 /** Routes for the main navigation */

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
@@ -1,0 +1,8 @@
+package de.amosproj3.ziofa.ui
+
+/** Routes for the main navigation */
+enum class Routes {
+    Visualize,
+    Configuration,
+    About,
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui
 
 import androidx.compose.foundation.layout.fillMaxSize

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
@@ -1,0 +1,57 @@
+package de.amosproj3.ziofa.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import de.amosproj3.ziofa.ui.about.AboutScreen
+import de.amosproj3.ziofa.ui.configuration.ConfigurationScreen
+import de.amosproj3.ziofa.ui.navigation.ZiofaNavBarItem
+import de.amosproj3.ziofa.ui.navigation.ZiofaNavigationBar
+import de.amosproj3.ziofa.ui.navigation.ZiofaTopBar
+import de.amosproj3.ziofa.ui.visualization.VisualizationScreen
+
+/** Main application composable */
+@Composable
+fun ZIOFAApp() {
+    val navController = rememberNavController()
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = { ZiofaTopBar() },
+        bottomBar = {
+            ZiofaNavigationBar(
+                navBarItems =
+                    listOf(
+                        ZiofaNavBarItem(text = "Configuration", icon = Icons.Filled.Settings) {
+                            navController.navigate(Routes.Configuration.name)
+                        },
+                        ZiofaNavBarItem(text = "Visualize", icon = Icons.Filled.PlayArrow) {
+                            navController.navigate(Routes.Visualize.name)
+                        },
+                        ZiofaNavBarItem(text = "About", icon = Icons.Filled.Info) {
+                            navController.navigate(Routes.About.name)
+                        },
+                    )
+            )
+        },
+    ) { innerPadding ->
+        NavHost(
+            navController,
+            modifier = Modifier.padding(innerPadding).fillMaxSize(),
+            startDestination = Routes.Configuration.name,
+        ) {
+            composable(Routes.Configuration.name) { ConfigurationScreen() }
+            composable(Routes.Visualize.name) { VisualizationScreen() }
+            composable(Routes.About.name) { AboutScreen() }
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/about/AboutScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/about/AboutScreen.kt
@@ -1,0 +1,15 @@
+package de.amosproj3.ziofa.ui.about
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Screen containing information about the project. Might delete later if we need space for another
+ * screen in the tab bar.
+ */
+@Composable
+fun AboutScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier) { Text("This is the about screen") }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/about/AboutScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/about/AboutScreen.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.about
 
 import androidx.compose.foundation.layout.Box

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.configuration
 
 import androidx.compose.foundation.layout.Box

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
@@ -1,0 +1,12 @@
+package de.amosproj3.ziofa.ui.configuration
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/** Screen for configuring eBPF programs */
+@Composable
+fun ConfigurationScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier) { Text("This is the configuration screen") }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBar.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBar.kt
@@ -1,0 +1,30 @@
+package de.amosproj3.ziofa.ui.navigation
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/** Main nav bar for the app */
+@Composable
+fun ZiofaNavigationBar(navBarItems: List<ZiofaNavBarItem>) {
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    NavigationBar {
+        navBarItems.forEachIndexed { index, tarBarItem ->
+            NavigationBarItem(
+                selected = selectedTabIndex == index,
+                icon = { Icon(tarBarItem.icon, contentDescription = tarBarItem.text) },
+                onClick = {
+                    selectedTabIndex = index
+                    tarBarItem.onClick()
+                },
+                label = { Text(tarBarItem.text) },
+            )
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBar.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBar.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.navigation
 
 import androidx.compose.material3.Icon

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBarItem.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBarItem.kt
@@ -1,0 +1,5 @@
+package de.amosproj3.ziofa.ui.navigation
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class ZiofaNavBarItem(val text: String, val icon: ImageVector, val onClick: () -> Unit)

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBarItem.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaNavBarItem.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.navigation
 
 import androidx.compose.ui.graphics.vector.ImageVector

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaTopBar.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaTopBar.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.navigation
 
 import androidx.compose.foundation.layout.Arrangement

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaTopBar.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ZiofaTopBar.kt
@@ -1,0 +1,42 @@
+package de.amosproj3.ziofa.ui.navigation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.dp
+
+/** Top bar containing the app name and AMOS text */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ZiofaTopBar() {
+    TopAppBar(
+        {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Zero Instrumentation Observability for Android")
+                Text(
+                    "made as part of AMOS",
+                    modifier = Modifier.padding(end = 20.dp),
+                    fontStyle = FontStyle.Italic,
+                )
+            }
+        },
+        colors =
+            TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                titleContentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+        scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(),
+    )
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/Counter.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/Counter.kt
@@ -1,0 +1,65 @@
+package de.amosproj3.ziofa.ui.visualization
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import de.amosproj3.ziofa.client.Client
+import de.amosproj3.ziofa.client.ClientFactory
+import kotlinx.coroutines.launch
+
+/** Counter example by Felix */
+@Composable
+fun Counter(clientFactory: ClientFactory, modifier: Modifier = Modifier) {
+    var client by remember { mutableStateOf<Client?>(null) }
+    var waiting by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+    var maybeCount by remember { mutableStateOf(0u) }
+
+    LaunchedEffect(client) {
+        client?.loadProgram("example")
+        client?.serverCount?.collect { maybeCount = it }
+    }
+
+    Box(contentAlignment = Alignment.Center, modifier = modifier.fillMaxSize()) {
+        if (client != null) {
+            Text("$maybeCount")
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(
+                    onClick = {
+                        waiting = true
+                        error = null
+                        scope.launch {
+                            try {
+                                client = clientFactory.connect(scope, "http://[::1]:50051")
+                            } catch (e: Exception) {
+                                error = e.message
+                            }
+                            waiting = false
+                        }
+                    },
+                    enabled = !waiting,
+                ) {
+                    Text("Connect")
+                }
+                error?.let { Text(it, style = LocalTextStyle.current.copy(color = Color.Red)) }
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/Counter.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/Counter.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.visualization
 
 import androidx.compose.foundation.layout.Arrangement

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/VisualizationScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/VisualizationScreen.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.visualization
 
 import androidx.compose.foundation.layout.Box

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/VisualizationScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/VisualizationScreen.kt
@@ -1,0 +1,20 @@
+package de.amosproj3.ziofa.ui.visualization
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import de.amosproj3.ziofa.client.ClientFactory
+import org.koin.compose.koinInject
+
+/** Screen for visualizing data. */
+@Composable
+fun VisualizationScreen(
+    modifier: Modifier = Modifier,
+    clientFactory: ClientFactory = koinInject(),
+) {
+    Box(modifier = modifier) {
+        Text("This is the visualization screen")
+        Counter(clientFactory = clientFactory)
+    }
+}

--- a/frontend/gradle/libs.versions.toml
+++ b/frontend/gradle/libs.versions.toml
@@ -6,22 +6,21 @@ activityCompose = "1.9.3"
 # @pin incompatible otherwise
 agp = "8.6.0"
 benmanes-versions = "0.51.0"
+compose-navigation = "2.8.0"
 composeBom = "2024.10.01"
 coreKtx = "1.15.0"
 cyclonedx = "1.10.0"
 espressoCore = "3.6.1"
+jna = "5.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 koin = "4.0.0"
 kotlin = "2.0.21"
 ktfmt = "0.20.1"
 lifecycleRuntimeKtx = "2.8.7"
-versioncatalogueupdate = "0.8.5"
 rust-android = "0.9.4"
-jna = "5.15.0"
 timber = "5.0.1"
-compose-navigation = "2.8.0"
-
+versioncatalogueupdate = "0.8.5"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -39,20 +38,20 @@ androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 jackwharton-timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 junit = { module = "junit:junit", version.ref = "junit" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
-jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
 com-github-benmanes-versions = { id = "com.github.ben-manes.versions", version.ref = "benmanes-versions" }
 com-ncorti-ktfmt-gradle = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 nl-littlerobots-versioncatalogueupdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versioncatalogueupdate" }
 org-cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }
-android-library = { id = "com.android.library", version.ref = "agp" }
 rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version.ref = "rust-android" }

--- a/frontend/gradle/libs.versions.toml
+++ b/frontend/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ lifecycleRuntimeKtx = "2.8.7"
 versioncatalogueupdate = "0.8.5"
 rust-android = "0.9.4"
 jna = "5.15.0"
+timber = "5.0.1"
+compose-navigation = "2.8.0"
+
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -28,12 +31,14 @@ androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", vers
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-material3 = { module = "androidx.compose.material3:material3" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "compose-navigation" }
 androidx-ui = { module = "androidx.compose.ui:ui" }
 androidx-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+jackwharton-timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 junit = { module = "junit:junit", version.ref = "junit" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }


### PR DESCRIPTION
This commit adds the basic navigation logic to the UI as well as a navbar at the bottom that allows navigation using tabs. Additionaly, we display a topbar for the app name.

For screenshots, see #43 , first screenshot.

Closes #43 