### PR TITLE
Fix: process listing too short comm field

### DIFF
--- a/rust/backend/daemon/src/.gitignore
+++ b/rust/backend/daemon/src/.gitignore
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
+#
+# SPDX-License-Identifier: MIT
+
+!bin

--- a/rust/shared/proto/ziofa.proto
+++ b/rust/shared/proto/ziofa.proto
@@ -31,8 +31,15 @@ message ProcessList {
 message Process {
     int32 pid = 1;
     int32 ppid = 2;
-    string comm = 3;
-    string state = 4;
+    oneof cmd {
+        Cmdline cmdline = 3;
+        string comm = 4;
+    }
+    string state = 5;
+}
+
+message Cmdline {
+    repeated string args = 1;
 }
 
 message SetConfigurationResponse{


### PR DESCRIPTION
Now the cmdline of the processes will get transmitted. comm is still used as fallback. This change is needed as the comm field is being truncated to 16 chars incl. NULL and thus often too short to fit the relevant things.

See 3.6 of https://www.kernel.org/doc/html/latest/filesystems/proc.html