### PR TITLE
Client SDK Integration + Process Screen + Variants

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,6 +11,10 @@ SPDX-License-Identifier: MIT
 `./gradlew build` <br/>
 The resulting APKs for release/debug build types can then be found under `frontend/app/build/outputs/apk`.
 
+### Installing the app:
+`./gradlew installRealBackendDebug` or `./gradlew iRBD` for installing a version with a **real** backend <br/>
+`./gradlew installMockBackendDebug` or `./gradlew iMBD` for installing a version with a **mocked** backend <br/>
+
 ### Generating the report for the bill of materials (BOM)
 To generate a BOM of all *release runtime dependencies*, the following Gradle task can be run: <br/>
 `./gradlew cyclonedxBom` <br/>

--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -60,6 +60,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
@@ -67,6 +68,17 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+
+    flavorDimensions += "environment"
+    productFlavors {
+        create("realBackend") {
+            dimension = "environment"
+        }
+        create("mockedBackend") {
+            dimension = "environment"
+            versionNameSuffix = ".mocked"  // Optional
         }
     }
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
@@ -8,9 +8,9 @@ import android.app.Application
 import de.amosproj3.ziofa.api.ConfigurationAccess
 import de.amosproj3.ziofa.api.ProcessListAccess
 import de.amosproj3.ziofa.bl.ConfigurationManager
-import de.amosproj3.ziofa.client.mocks.MockClientFactory
 import de.amosproj3.ziofa.client.ClientFactory
 import de.amosproj3.ziofa.client.RustClientFactory
+import de.amosproj3.ziofa.client.mocks.MockClientFactory
 import de.amosproj3.ziofa.ui.configuration.ConfigurationViewModel
 import de.amosproj3.ziofa.ui.processes.ProcessesViewModel
 import de.amosproj3.ziofa.ui.visualization.VisualizationViewModel
@@ -32,10 +32,8 @@ class ZiofaApplication : Application() {
                 RustClientFactory("http://[::1]:50051")
             }
         }
-        single { ConfigurationManager(clientFactory = get()) } binds arrayOf(
-            ConfigurationAccess::class,
-            ProcessListAccess::class
-        )
+        single { ConfigurationManager(clientFactory = get()) } binds
+            arrayOf(ConfigurationAccess::class, ProcessListAccess::class)
         viewModel { ConfigurationViewModel(configurationAccess = get()) }
         viewModel { ProcessesViewModel(processListAccess = get()) }
         viewModel { VisualizationViewModel(clientFactory = get()) }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
@@ -5,23 +5,40 @@
 package de.amosproj3.ziofa
 
 import android.app.Application
+import de.amosproj3.ziofa.api.ConfigurationAccess
+import de.amosproj3.ziofa.api.ProcessListAccess
+import de.amosproj3.ziofa.bl.ConfigurationManager
+import de.amosproj3.ziofa.client.mocks.MockClientFactory
 import de.amosproj3.ziofa.client.ClientFactory
 import de.amosproj3.ziofa.client.RustClientFactory
 import de.amosproj3.ziofa.ui.configuration.ConfigurationViewModel
+import de.amosproj3.ziofa.ui.processes.ProcessesViewModel
 import de.amosproj3.ziofa.ui.visualization.VisualizationViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.binds
 import org.koin.dsl.module
 import timber.log.Timber
 
 class ZiofaApplication : Application() {
 
     val appModule = module {
-        single<ClientFactory> { RustClientFactory("http://[::1]:50051") }
-        viewModel { ConfigurationViewModel() }
-        viewModel { VisualizationViewModel(get()) }
+        single<ClientFactory> {
+            if (BuildConfig.FLAVOR == "mockedBackend") {
+                MockClientFactory()
+            } else {
+                RustClientFactory("http://[::1]:50051")
+            }
+        }
+        single { ConfigurationManager(clientFactory = get()) } binds arrayOf(
+            ConfigurationAccess::class,
+            ProcessListAccess::class
+        )
+        viewModel { ConfigurationViewModel(configurationAccess = get()) }
+        viewModel { ProcessesViewModel(processListAccess = get()) }
+        viewModel { VisualizationViewModel(clientFactory = get()) }
     }
 
     override fun onCreate() {

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationAccess.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationAccess.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.api
 
 import kotlinx.coroutines.flow.StateFlow
@@ -5,5 +9,6 @@ import uniffi.shared.Configuration
 
 interface ConfigurationAccess {
     val configuration: StateFlow<ConfigurationUpdate>
+
     fun submitConfiguration(configuration: Configuration)
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationAccess.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationAccess.kt
@@ -1,0 +1,9 @@
+package de.amosproj3.ziofa.api
+
+import kotlinx.coroutines.flow.StateFlow
+import uniffi.shared.Configuration
+
+interface ConfigurationAccess {
+    val configuration: StateFlow<ConfigurationUpdate>
+    fun submitConfiguration(configuration: Configuration)
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationUpdate.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationUpdate.kt
@@ -1,0 +1,10 @@
+package de.amosproj3.ziofa.api
+
+import uniffi.shared.Configuration
+
+sealed class ConfigurationUpdate {
+    data class OK(val configuration: Configuration) : ConfigurationUpdate()
+    data class NOK(val error: Throwable) : ConfigurationUpdate()
+    data object UNKNOWN : ConfigurationUpdate()
+}
+

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationUpdate.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/ConfigurationUpdate.kt
@@ -1,10 +1,15 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.api
 
 import uniffi.shared.Configuration
 
 sealed class ConfigurationUpdate {
     data class OK(val configuration: Configuration) : ConfigurationUpdate()
+
     data class NOK(val error: Throwable) : ConfigurationUpdate()
+
     data object UNKNOWN : ConfigurationUpdate()
 }
-

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/ProcessListAccess.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/ProcessListAccess.kt
@@ -1,0 +1,8 @@
+package de.amosproj3.ziofa.api
+
+import kotlinx.coroutines.flow.StateFlow
+import uniffi.shared.Process
+
+interface ProcessListAccess {
+    val processesList: StateFlow<List<Process>>
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/ProcessListAccess.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/ProcessListAccess.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.api
 
 import kotlinx.coroutines.flow.StateFlow

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/bl/ConfigurationManager.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/bl/ConfigurationManager.kt
@@ -1,0 +1,81 @@
+package de.amosproj3.ziofa.bl
+
+import android.util.Log
+import de.amosproj3.ziofa.api.ConfigurationAccess
+import de.amosproj3.ziofa.api.ConfigurationUpdate
+import de.amosproj3.ziofa.api.ProcessListAccess
+import de.amosproj3.ziofa.client.Client
+import de.amosproj3.ziofa.client.ClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uniffi.client.ClientException
+import uniffi.shared.Configuration
+import uniffi.shared.Process
+
+class ConfigurationManager(val clientFactory: ClientFactory) :
+    ProcessListAccess, ConfigurationAccess {
+
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+    private var client: Client? = null
+
+    override val processesList = MutableStateFlow<List<Process>>(listOf())
+    override val configuration: MutableStateFlow<ConfigurationUpdate> =
+        MutableStateFlow(ConfigurationUpdate.UNKNOWN)
+
+    override fun submitConfiguration(configuration: Configuration) {
+        coroutineScope.launch {
+            client?.setConfiguration(configuration)
+            getAndUpdateConfiguration() // "emulates" callback of changed configuration until implemented
+        }
+    }
+
+    init {
+        coroutineScope.launch {
+            try {
+                client = clientFactory.connect()
+                initializeConfigurationState()
+                startProcessListUpdates()
+            } catch (e: ClientException) {
+                configuration.update { ConfigurationUpdate.NOK(e) }
+            }
+        }
+    }
+
+    private suspend fun initializeConfigurationState() {
+        val initializedConfiguration = try {
+            client!!.getConfiguration()
+        } catch (e: ClientException) {
+            // TODO this should be handled on the backend
+            client!!.setConfiguration(Configuration(listOf()))
+            client!!.getConfiguration()
+        }
+        configuration.update { ConfigurationUpdate.OK(initializedConfiguration) }
+    }
+
+
+    private suspend fun startProcessListUpdates() {
+        while (true) {
+            delay(1000)
+            client?.let { client -> processesList.update { client.listProcesses() } }
+                ?: processesList.update { listOf() }
+                    .also { Log.w("Process List", "Client not ready!") }
+        }
+    }
+
+    private suspend fun getAndUpdateConfiguration() {
+        configuration.update {
+            try {
+                (client?.getConfiguration()?.let {
+                    ConfigurationUpdate.OK(it)
+                } ?: ConfigurationUpdate.UNKNOWN)
+                    .also { Log.e("RECEIVED CONFIG", "$it") }
+            } catch (e: Exception) {
+                ConfigurationUpdate.NOK(e)
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
@@ -10,5 +10,5 @@ enum class Routes {
     Configuration,
     About,
     Home,
-    Processes
+    Processes,
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
@@ -10,4 +10,5 @@ enum class Routes {
     Configuration,
     About,
     Home,
+    Processes
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
@@ -22,6 +22,7 @@ import de.amosproj3.ziofa.ui.about.AboutScreen
 import de.amosproj3.ziofa.ui.configuration.ConfigurationScreen
 import de.amosproj3.ziofa.ui.navigation.HomeScreen
 import de.amosproj3.ziofa.ui.navigation.composables.ZiofaTopBar
+import de.amosproj3.ziofa.ui.processes.ProcessesScreen
 import de.amosproj3.ziofa.ui.visualization.VisualizationScreen
 
 /** Main application composable. All calls to [NavController] should happen here. */
@@ -29,8 +30,9 @@ import de.amosproj3.ziofa.ui.visualization.VisualizationScreen
 fun ZIOFAApp() {
     val navController = rememberNavController()
 
-    Scaffold(modifier = Modifier.fillMaxSize(), topBar = { DynamicTopBar(navController) }) {
-        innerPadding ->
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = { DynamicTopBar(navController) }) { innerPadding ->
         NavHost(
             navController,
             modifier = Modifier.fillMaxSize(),
@@ -41,6 +43,7 @@ fun ZIOFAApp() {
                     toVisualize = { navController.navigate(Routes.Visualize.name) },
                     toConfiguration = { navController.navigate(Routes.Configuration.name) },
                     toAbout = { navController.navigate(Routes.About.name) },
+                    toProcesses = { navController.navigate(Routes.Processes.name) },
                     modifier = Modifier.padding(innerPadding),
                 )
             }
@@ -49,7 +52,9 @@ fun ZIOFAApp() {
                 enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
                 exitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() },
             ) {
-                ConfigurationScreen(Modifier.padding(innerPadding))
+                ConfigurationScreen(Modifier.padding(innerPadding), onBack = {
+                    navController.backToHome()
+                })
             }
             composable(
                 Routes.Visualize.name,
@@ -64,6 +69,14 @@ fun ZIOFAApp() {
                 exitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() },
             ) {
                 AboutScreen(Modifier.padding(innerPadding))
+            }
+
+            composable(
+                Routes.Processes.name,
+                enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
+                exitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() },
+            ) {
+                ProcessesScreen(Modifier.padding(innerPadding))
             }
         }
     }
@@ -85,12 +98,16 @@ fun DynamicTopBar(navController: NavController) {
                 ZiofaTopBar(
                     screenName = currentRoute,
                     onBack = {
-                        navController.navigate(Routes.Home.name) {
-                            popUpTo(Routes.Home.name) { inclusive = false }
-                        }
+                        navController.backToHome()
                     },
                 )
             }
         }
+    }
+}
+
+fun NavController.backToHome() {
+    this.navigate(Routes.Home.name) {
+        popUpTo(Routes.Home.name) { inclusive = false }
     }
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
@@ -30,9 +30,8 @@ import de.amosproj3.ziofa.ui.visualization.VisualizationScreen
 fun ZIOFAApp() {
     val navController = rememberNavController()
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        topBar = { DynamicTopBar(navController) }) { innerPadding ->
+    Scaffold(modifier = Modifier.fillMaxSize(), topBar = { DynamicTopBar(navController) }) {
+        innerPadding ->
         NavHost(
             navController,
             modifier = Modifier.fillMaxSize(),
@@ -52,9 +51,10 @@ fun ZIOFAApp() {
                 enterTransition = { slideInHorizontally(initialOffsetX = { it }) + fadeIn() },
                 exitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() },
             ) {
-                ConfigurationScreen(Modifier.padding(innerPadding), onBack = {
-                    navController.backToHome()
-                })
+                ConfigurationScreen(
+                    Modifier.padding(innerPadding),
+                    onBack = { navController.backToHome() },
+                )
             }
             composable(
                 Routes.Visualize.name,
@@ -95,19 +95,12 @@ fun DynamicTopBar(navController: NavController) {
             }
 
             else -> {
-                ZiofaTopBar(
-                    screenName = currentRoute,
-                    onBack = {
-                        navController.backToHome()
-                    },
-                )
+                ZiofaTopBar(screenName = currentRoute, onBack = { navController.backToHome() })
             }
         }
     }
 }
 
 fun NavController.backToHome() {
-    this.navigate(Routes.Home.name) {
-        popUpTo(Routes.Home.name) { inclusive = false }
-    }
+    this.navigate(Routes.Home.name) { popUpTo(Routes.Home.name) { inclusive = false } }
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
@@ -6,26 +6,37 @@ package de.amosproj3.ziofa.ui.configuration
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import de.amosproj3.ziofa.ui.configuration.composables.EbpfOptions
+import de.amosproj3.ziofa.ui.configuration.composables.ErrorScreen
+import de.amosproj3.ziofa.ui.configuration.composables.SubmitFab
+import de.amosproj3.ziofa.ui.configuration.data.ConfigurationScreenState
 import org.koin.androidx.compose.koinViewModel
 
 /** Screen for configuring eBPF programs */
@@ -34,30 +45,40 @@ import org.koin.androidx.compose.koinViewModel
 fun ConfigurationScreen(
     modifier: Modifier = Modifier,
     viewModel: ConfigurationViewModel = koinViewModel(),
+    onBack: () -> Unit = {}
 ) {
     Box(modifier = modifier.fillMaxSize()) {
-        val options = viewModel.programList.collectAsState().value
-        LazyColumn(modifier = Modifier.padding(horizontal = 20.dp).fillMaxSize()) {
-            item { Spacer(Modifier.height(15.dp)) }
-            items(options) { option ->
-                Row(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(option.name)
-                    Checkbox(
-                        checked = option.active,
-                        onCheckedChange = { viewModel.optionChanged(option, it) },
-                    )
+        val screenState by remember { viewModel.configurationScreenState }.collectAsState()
+        val configurationChangedByUser by remember { viewModel.changed }.collectAsState()
+        when (val state = screenState) { // needed for immutability
+            is ConfigurationScreenState.LIST -> {
+
+                // Render list of options
+                EbpfOptions(options = state.options, onCheckedChanged = { option, newValue ->
+                    viewModel.optionChanged(option, newValue)
+                })
+
+                // Show the submit button if the user changed settings
+                if (configurationChangedByUser) {
+                    SubmitFab(
+                        modifier = Modifier.align(
+                            Alignment.BottomEnd,
+                        ), onClick = {
+                            viewModel.configurationSubmitted()
+                        })
                 }
             }
+
+            is ConfigurationScreenState.ERROR -> {
+                ErrorScreen(state.errorMessage, onBack)
+            }
+
+            is ConfigurationScreenState.LOADING -> {
+                // Display loading anim while state is unknown
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
         }
-        ExtendedFloatingActionButton(
-            modifier = Modifier.align(Alignment.BottomEnd).padding(end = 25.dp, bottom = 25.dp),
-            onClick = { viewModel.configurationSubmitted() },
-            icon = { Icon(imageVector = Icons.AutoMirrored.Default.Send, contentDescription = "") },
-            text = { Text("Submit") },
-        )
     }
 }
+
+

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
@@ -4,35 +4,17 @@
 
 package de.amosproj3.ziofa.ui.configuration
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import de.amosproj3.ziofa.ui.configuration.composables.EbpfOptions
 import de.amosproj3.ziofa.ui.configuration.composables.ErrorScreen
 import de.amosproj3.ziofa.ui.configuration.composables.SubmitFab
@@ -45,7 +27,7 @@ import org.koin.androidx.compose.koinViewModel
 fun ConfigurationScreen(
     modifier: Modifier = Modifier,
     viewModel: ConfigurationViewModel = koinViewModel(),
-    onBack: () -> Unit = {}
+    onBack: () -> Unit = {},
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         val screenState by remember { viewModel.configurationScreenState }.collectAsState()
@@ -54,18 +36,19 @@ fun ConfigurationScreen(
             is ConfigurationScreenState.LIST -> {
 
                 // Render list of options
-                EbpfOptions(options = state.options, onCheckedChanged = { option, newValue ->
-                    viewModel.optionChanged(option, newValue)
-                })
+                EbpfOptions(
+                    options = state.options,
+                    onCheckedChanged = { option, newValue ->
+                        viewModel.optionChanged(option, newValue)
+                    },
+                )
 
                 // Show the submit button if the user changed settings
                 if (configurationChangedByUser) {
                     SubmitFab(
-                        modifier = Modifier.align(
-                            Alignment.BottomEnd,
-                        ), onClick = {
-                            viewModel.configurationSubmitted()
-                        })
+                        modifier = Modifier.align(Alignment.BottomEnd),
+                        onClick = { viewModel.configurationSubmitted() },
+                    )
                 }
             }
 
@@ -80,5 +63,3 @@ fun ConfigurationScreen(
         }
     }
 }
-
-

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationViewModel.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationViewModel.kt
@@ -4,50 +4,100 @@
 
 package de.amosproj3.ziofa.ui.configuration
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import de.amosproj3.ziofa.api.ConfigurationAccess
+import de.amosproj3.ziofa.api.ConfigurationUpdate
+import de.amosproj3.ziofa.ui.configuration.data.ConfigurationScreenState
 import de.amosproj3.ziofa.ui.configuration.data.EBpfProgramOption
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import timber.log.Timber
+import kotlinx.coroutines.launch
+import uniffi.shared.Configuration
 
-class ConfigurationViewModel : ViewModel() {
 
-    val mockOptions =
-        mutableListOf(
-                EBpfProgramOption("uprobe 1", false),
-                EBpfProgramOption("uprobe 2", true),
-                EBpfProgramOption("uprobe 3", true),
-                EBpfProgramOption("uprobe 4", true),
-                EBpfProgramOption("uprobe 5", true),
-                EBpfProgramOption("uprobe 6", true),
-                EBpfProgramOption("uprobe 7", true),
-                EBpfProgramOption("uprobe 8", true),
-                EBpfProgramOption("uprobe 9", true),
-                EBpfProgramOption("uprobe 10", true),
-                EBpfProgramOption("uprobe 11", true),
-                EBpfProgramOption("uprobe 12", true),
-                EBpfProgramOption("uprobe 13", true),
-                EBpfProgramOption("uprobe 14", true),
-                EBpfProgramOption("uprobe 15", true),
-                EBpfProgramOption("uprobe 16", true),
-                EBpfProgramOption("uprobe 17", true),
-            )
-            .associateBy { it.name }
-            .toMutableMap() // TODO delete
+class ConfigurationViewModel(val configurationAccess: ConfigurationAccess) : ViewModel() {
 
-    private val _programList: MutableStateFlow<List<EBpfProgramOption>> =
-        MutableStateFlow(mockOptions.values.toList())
-    val programList: StateFlow<List<EBpfProgramOption>> = _programList.asStateFlow()
+    private val _changed = MutableStateFlow(false)
+    val changed = _changed.stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+    private val checkedOptions =
+        MutableStateFlow<MutableMap<String, EBpfProgramOption>>(mutableMapOf())
+
+    private val _configurationScreenState =
+        MutableStateFlow<ConfigurationScreenState>(ConfigurationScreenState.LOADING)
+    val configurationScreenState: StateFlow<ConfigurationScreenState> =
+        _configurationScreenState.onEach { Log.e("Configuration UI Update", it.toString()) }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, ConfigurationScreenState.LOADING)
+
+
+    init {
+        viewModelScope.launch {
+            updateUIFromBackend()
+        }
+    }
+
+    private suspend fun updateUIFromBackend() {
+        configurationAccess.configuration.collect { receivedConfiguration ->
+            _configurationScreenState.update { receivedConfiguration.toUIUpdate() }
+        }
+    }
 
     fun optionChanged(eBpfProgramOption: EBpfProgramOption, newState: Boolean) {
-        mockOptions[eBpfProgramOption.name] = EBpfProgramOption(eBpfProgramOption.name, newState)
-        _programList.update { mockOptions.values.toList() }
+        checkedOptions.update { currentMap ->
+            currentMap.computeIfPresent(eBpfProgramOption.name) { _, oldValue ->
+                oldValue.copy(active = newState)
+            }
+            currentMap
+        }
+        _configurationScreenState.update { ConfigurationScreenState.LIST(checkedOptions.value.values.toList()) }
+        _changed.update { true }
     }
 
     fun configurationSubmitted() {
-        Timber.i("configurationSubmitted")
-        // TODO send to backend and display popup with loading anim
+        viewModelScope.launch {
+            configurationAccess.submitConfiguration(checkedOptions.value.toConfiguration())
+        }
+        _changed.update { false }
     }
+
+    private fun ConfigurationUpdate.toUIUpdate(): ConfigurationScreenState {
+        return when (this) {
+            is ConfigurationUpdate.OK -> {
+                checkedOptions.update {
+                    this.toUIOptions().associateBy { it.name }
+                        .toMutableMap()
+                }
+                ConfigurationScreenState.LIST(checkedOptions.value.values.toList())
+            }
+
+            is ConfigurationUpdate.NOK -> ConfigurationScreenState.ERROR(
+                this.error.stackTraceToString()
+            )
+
+            is ConfigurationUpdate.UNKNOWN -> ConfigurationScreenState.LOADING
+        }
+    }
+
+    private fun ConfigurationUpdate.OK.toUIOptions(): List<EBpfProgramOption> {
+        return this.configuration.entries.map {
+            EBpfProgramOption(
+                it.hrName,
+                active = it.attach,
+                true,
+                it
+            )
+        }
+    }
+
+    private fun MutableMap<String, EBpfProgramOption>.toConfiguration(): Configuration {
+        return Configuration(this.values.map { it.ebpfEntry })
+    }
+
+
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/EbpfOptions.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/EbpfOptions.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.configuration.composables
 
 import androidx.compose.foundation.layout.Arrangement
@@ -19,13 +23,9 @@ import de.amosproj3.ziofa.ui.configuration.data.EBpfProgramOption
 @Composable
 fun EbpfOptions(
     options: List<EBpfProgramOption>,
-    onCheckedChanged: (EBpfProgramOption, Boolean) -> Unit
+    onCheckedChanged: (EBpfProgramOption, Boolean) -> Unit,
 ) {
-    LazyColumn(
-        modifier = Modifier
-            .padding(horizontal = 20.dp)
-            .fillMaxSize()
-    ) {
+    LazyColumn(modifier = Modifier.padding(horizontal = 20.dp).fillMaxSize()) {
         item { Spacer(Modifier.height(15.dp)) }
 
         items(options) { option ->
@@ -37,7 +37,7 @@ fun EbpfOptions(
                 Text(option.name)
                 Checkbox(
                     checked = option.active,
-                    onCheckedChange = { onCheckedChanged(option, it) }
+                    onCheckedChange = { onCheckedChanged(option, it) },
                 )
             }
         }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/EbpfOptions.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/EbpfOptions.kt
@@ -1,0 +1,45 @@
+package de.amosproj3.ziofa.ui.configuration.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import de.amosproj3.ziofa.ui.configuration.data.EBpfProgramOption
+
+@Composable
+fun EbpfOptions(
+    options: List<EBpfProgramOption>,
+    onCheckedChanged: (EBpfProgramOption, Boolean) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier
+            .padding(horizontal = 20.dp)
+            .fillMaxSize()
+    ) {
+        item { Spacer(Modifier.height(15.dp)) }
+
+        items(options) { option ->
+            Row(
+                modifier = Modifier.fillMaxSize(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(option.name)
+                Checkbox(
+                    checked = option.active,
+                    onCheckedChange = { onCheckedChanged(option, it) }
+                )
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/ErrorScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/ErrorScreen.kt
@@ -1,0 +1,48 @@
+package de.amosproj3.ziofa.ui.configuration.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+
+@Preview(device = Devices.AUTOMOTIVE_1024p)
+@Composable
+fun ErrorScreen(error: String = "No error message available", onBack: () -> Unit = {}) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Error while retrieving configuration",
+                color = Color.Red,
+                fontSize = TextUnit(25f, TextUnitType.Sp)
+            )
+            Text(text = error)
+        }
+        Button(
+            onBack,
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 20.dp)
+        ) { Text("Back to home screen") }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/ErrorScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/ErrorScreen.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.configuration.composables
 
 import androidx.compose.foundation.layout.Box
@@ -13,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
@@ -25,24 +28,22 @@ import androidx.compose.ui.unit.dp
 fun ErrorScreen(error: String = "No error message available", onBack: () -> Unit = {}) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
+            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = "Error while retrieving configuration",
                 color = Color.Red,
-                fontSize = TextUnit(25f, TextUnitType.Sp)
+                fontSize = TextUnit(25f, TextUnitType.Sp),
             )
             Text(text = error)
         }
         Button(
             onBack,
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter)
-                .padding(horizontal = 20.dp)
-        ) { Text("Back to home screen") }
+            modifier =
+                Modifier.fillMaxWidth().align(Alignment.BottomCenter).padding(horizontal = 20.dp),
+        ) {
+            Text("Back to home screen")
+        }
     }
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/SubmitFab.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/SubmitFab.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.configuration.composables
 
 import androidx.compose.foundation.layout.padding
@@ -16,15 +20,9 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun SubmitFab(modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
     ExtendedFloatingActionButton(
-        modifier = modifier
-            .padding(end = 25.dp, bottom = 25.dp),
+        modifier = modifier.padding(end = 25.dp, bottom = 25.dp),
         onClick = onClick,
-        icon = {
-            Icon(
-                imageVector = Icons.AutoMirrored.Default.Send,
-                contentDescription = ""
-            )
-        },
+        icon = { Icon(imageVector = Icons.AutoMirrored.Default.Send, contentDescription = "") },
         text = { Text("Submit") },
     )
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/SubmitFab.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/composables/SubmitFab.kt
@@ -1,0 +1,30 @@
+package de.amosproj3.ziofa.ui.configuration.composables
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Preview(device = Devices.AUTOMOTIVE_1024p)
+@Composable
+fun SubmitFab(modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
+    ExtendedFloatingActionButton(
+        modifier = modifier
+            .padding(end = 25.dp, bottom = 25.dp),
+        onClick = onClick,
+        icon = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Default.Send,
+                contentDescription = ""
+            )
+        },
+        text = { Text("Submit") },
+    )
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/ConfigurationScreenState.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/ConfigurationScreenState.kt
@@ -1,7 +1,13 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.configuration.data
 
 sealed class ConfigurationScreenState {
     data class LIST(val options: List<EBpfProgramOption>) : ConfigurationScreenState()
-    data class ERROR(val errorMessage:String) : ConfigurationScreenState()
+
+    data class ERROR(val errorMessage: String) : ConfigurationScreenState()
+
     data object LOADING : ConfigurationScreenState()
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/ConfigurationScreenState.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/ConfigurationScreenState.kt
@@ -1,0 +1,7 @@
+package de.amosproj3.ziofa.ui.configuration.data
+
+sealed class ConfigurationScreenState {
+    data class LIST(val options: List<EBpfProgramOption>) : ConfigurationScreenState()
+    data class ERROR(val errorMessage:String) : ConfigurationScreenState()
+    data object LOADING : ConfigurationScreenState()
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/EBpfProgramOption.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/EBpfProgramOption.kt
@@ -9,6 +9,6 @@ import uniffi.shared.EbpfEntry
 data class EBpfProgramOption(
     val name: String,
     val active: Boolean,
-    val confirmed: Boolean, //TODO show diff
-    val ebpfEntry: EbpfEntry
+    val confirmed: Boolean, // TODO show diff
+    val ebpfEntry: EbpfEntry,
 )

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/EBpfProgramOption.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/data/EBpfProgramOption.kt
@@ -4,4 +4,11 @@
 
 package de.amosproj3.ziofa.ui.configuration.data
 
-data class EBpfProgramOption(val name: String, val active: Boolean)
+import uniffi.shared.EbpfEntry
+
+data class EBpfProgramOption(
+    val name: String,
+    val active: Boolean,
+    val confirmed: Boolean, //TODO show diff
+    val ebpfEntry: EbpfEntry
+)

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/HomeScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/HomeScreen.kt
@@ -38,6 +38,7 @@ fun HomeScreen(
     toVisualize: () -> Unit = {},
     toConfiguration: () -> Unit = {},
     toAbout: () -> Unit = {},
+    toProcesses: ()->Unit = {}
 ) {
     Box(
         modifier =
@@ -52,7 +53,8 @@ fun HomeScreen(
                     listOf(
                         MenuOptionData(title = "Visualize", "\uD83D\uDCCA", toVisualize),
                         MenuOptionData(title = "Configuration", "⚙\uFE0F", toConfiguration),
-                        MenuOptionData(title = "About", "ℹ\uFE0F", toAbout),
+                        MenuOptionData(title = "Processes", "\uD83D\uDD0E", toProcesses),
+                        MenuOptionData(title = "About", "ℹ\uFE0F", toAbout)
                     )
             )
         }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/HomeScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/HomeScreen.kt
@@ -38,7 +38,7 @@ fun HomeScreen(
     toVisualize: () -> Unit = {},
     toConfiguration: () -> Unit = {},
     toAbout: () -> Unit = {},
-    toProcesses: ()->Unit = {}
+    toProcesses: () -> Unit = {},
 ) {
     Box(
         modifier =
@@ -54,7 +54,7 @@ fun HomeScreen(
                         MenuOptionData(title = "Visualize", "\uD83D\uDCCA", toVisualize),
                         MenuOptionData(title = "Configuration", "⚙\uFE0F", toConfiguration),
                         MenuOptionData(title = "Processes", "\uD83D\uDD0E", toProcesses),
-                        MenuOptionData(title = "About", "ℹ\uFE0F", toAbout)
+                        MenuOptionData(title = "About", "ℹ\uFE0F", toAbout),
                     )
             )
         }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesScreen.kt
@@ -1,0 +1,65 @@
+package de.amosproj3.ziofa.ui.processes
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.koin.androidx.compose.koinViewModel
+import uniffi.shared.Cmd
+
+@Composable
+fun ProcessesScreen(modifier: Modifier, viewModel: ProcessesViewModel = koinViewModel()) {
+    Box(modifier = modifier.fillMaxSize()) {
+
+        Column {
+            Row(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
+                Text(text = "CMD", modifier = Modifier.weight(1f))
+                Text(text = "State", modifier = Modifier.weight(1f))
+                Text(text = "PID", modifier = Modifier.weight(1f))
+                Text(text = "Parent PID", modifier = Modifier.weight(1f))
+            }
+
+            val options by remember { viewModel.processesList }.collectAsState()
+            LazyColumn(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp)
+                    .fillMaxSize()
+            ) {
+                items(options) { option ->
+                    Row(
+                        modifier = Modifier.fillMaxSize(),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.Top,
+                    ) {
+                        Text(text = option.cmd.toReadableString(), modifier = Modifier.weight(1f))
+                        Text(text = option.state, modifier = Modifier.weight(1f))
+                        Text(text = option.pid.toString(), modifier = Modifier.weight(1f))
+                        Text(text = option.ppid.toString(), modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun Cmd?.toReadableString(): String {
+    this?.let {
+        return when (this) {
+            is Cmd.Comm -> this.v1
+            is Cmd.Cmdline -> this.v1.args.joinToString(" ")
+        }
+    } ?: return "null"
+
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesScreen.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.processes
 
 import androidx.compose.foundation.layout.Arrangement
@@ -22,7 +26,6 @@ import uniffi.shared.Cmd
 @Composable
 fun ProcessesScreen(modifier: Modifier, viewModel: ProcessesViewModel = koinViewModel()) {
     Box(modifier = modifier.fillMaxSize()) {
-
         Column {
             Row(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
                 Text(text = "CMD", modifier = Modifier.weight(1f))
@@ -32,11 +35,7 @@ fun ProcessesScreen(modifier: Modifier, viewModel: ProcessesViewModel = koinView
             }
 
             val options by remember { viewModel.processesList }.collectAsState()
-            LazyColumn(
-                modifier = Modifier
-                    .padding(horizontal = 20.dp)
-                    .fillMaxSize()
-            ) {
+            LazyColumn(modifier = Modifier.padding(horizontal = 20.dp).fillMaxSize()) {
                 items(options) { option ->
                     Row(
                         modifier = Modifier.fillMaxSize(),
@@ -61,5 +60,4 @@ fun Cmd?.toReadableString(): String {
             is Cmd.Cmdline -> this.v1.args.joinToString(" ")
         }
     } ?: return "null"
-
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesViewModel.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesViewModel.kt
@@ -1,0 +1,18 @@
+package de.amosproj3.ziofa.ui.processes
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import de.amosproj3.ziofa.api.ProcessListAccess
+import de.amosproj3.ziofa.bl.ConfigurationManager
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+class ProcessesViewModel(processListAccess: ProcessListAccess) : ViewModel() {
+    val processesList =
+        processListAccess.processesList.map { sortKey -> sortKey.sortedBy { it.pid } }.stateIn(
+            viewModelScope,
+            started = SharingStarted.Lazily,
+            listOf()
+        )
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesViewModel.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesViewModel.kt
@@ -1,18 +1,19 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.ui.processes
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import de.amosproj3.ziofa.api.ProcessListAccess
-import de.amosproj3.ziofa.bl.ConfigurationManager
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 class ProcessesViewModel(processListAccess: ProcessListAccess) : ViewModel() {
     val processesList =
-        processListAccess.processesList.map { sortKey -> sortKey.sortedBy { it.pid } }.stateIn(
-            viewModelScope,
-            started = SharingStarted.Lazily,
-            listOf()
-        )
+        processListAccess.processesList
+            .map { sortKey -> sortKey.sortedBy { it.pid } }
+            .stateIn(viewModelScope, started = SharingStarted.Lazily, listOf())
 }

--- a/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClient.kt
+++ b/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClient.kt
@@ -1,0 +1,84 @@
+package de.amosproj3.ziofa.client.mocks
+
+import de.amosproj3.ziofa.client.Client
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import uniffi.shared.Cmd
+import uniffi.shared.Configuration
+import uniffi.shared.EbpfEntry
+import uniffi.shared.Process
+import uniffi.shared.UprobeConfig
+import kotlin.random.Random
+import kotlin.random.nextUInt
+
+const val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+object MockClient : Client {
+    var configuration: Configuration = Configuration(
+        listOf(
+            EbpfEntry(
+                "Test HR name", "this is a test", "ebpf_name", 12345u,
+                UprobeConfig(0u, "target", 54321), "hook", false
+            )
+        )
+    )
+
+    override suspend fun serverCount(): Flow<UInt> =
+        flow {
+            var ctr = 0u
+            while (true) {
+                delay(Random.nextUInt(500u).toLong())
+                ctr++
+                emit(ctr)
+            }
+        }
+
+    override suspend fun load() {
+        //NOP
+    }
+
+    override suspend fun attach(iface: String) {
+        //NOP
+    }
+
+    override suspend fun unload() {
+        //NOP
+    }
+
+    override suspend fun detach(iface: String) {
+        //NOP
+    }
+
+    override suspend fun startCollecting() {
+        //NOP
+    }
+
+    override suspend fun stopCollecting() {
+        //NOP
+    }
+
+    override suspend fun checkServer() {
+        //NOP
+    }
+
+    override suspend fun listProcesses(): List<Process> {
+        return alphabet.indices.map {
+            Process(
+                pid = Random.nextUInt(1000u).toInt(),
+                ppid = Random.nextUInt(1000u).toInt(),
+                state = "R",
+                cmd = Cmd.Comm("/bin/sh/${alphabet.substring(it, it + 1)}")
+            )
+        }
+    }
+
+    override suspend fun getConfiguration(): Configuration {
+        return configuration
+    }
+
+    override suspend fun setConfiguration(configuration: Configuration) {
+        MockClient.configuration = configuration
+    }
+
+}

--- a/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClient.kt
+++ b/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClient.kt
@@ -1,6 +1,12 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.client.mocks
 
 import de.amosproj3.ziofa.client.Client
+import kotlin.random.Random
+import kotlin.random.nextUInt
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -9,57 +15,60 @@ import uniffi.shared.Configuration
 import uniffi.shared.EbpfEntry
 import uniffi.shared.Process
 import uniffi.shared.UprobeConfig
-import kotlin.random.Random
-import kotlin.random.nextUInt
 
 const val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 object MockClient : Client {
-    var configuration: Configuration = Configuration(
-        listOf(
-            EbpfEntry(
-                "Test HR name", "this is a test", "ebpf_name", 12345u,
-                UprobeConfig(0u, "target", 54321), "hook", false
+    var configuration: Configuration =
+        Configuration(
+            listOf(
+                EbpfEntry(
+                    "Test HR name",
+                    "this is a test",
+                    "ebpf_name",
+                    12345u,
+                    UprobeConfig(0u, "target", 54321),
+                    "hook",
+                    false,
+                )
             )
         )
-    )
 
-    override suspend fun serverCount(): Flow<UInt> =
-        flow {
-            var ctr = 0u
-            while (true) {
-                delay(Random.nextUInt(500u).toLong())
-                ctr++
-                emit(ctr)
-            }
+    override suspend fun serverCount(): Flow<UInt> = flow {
+        var ctr = 0u
+        while (true) {
+            delay(Random.nextUInt(500u).toLong())
+            ctr++
+            emit(ctr)
         }
+    }
 
     override suspend fun load() {
-        //NOP
+        // NOP
     }
 
     override suspend fun attach(iface: String) {
-        //NOP
+        // NOP
     }
 
     override suspend fun unload() {
-        //NOP
+        // NOP
     }
 
     override suspend fun detach(iface: String) {
-        //NOP
+        // NOP
     }
 
     override suspend fun startCollecting() {
-        //NOP
+        // NOP
     }
 
     override suspend fun stopCollecting() {
-        //NOP
+        // NOP
     }
 
     override suspend fun checkServer() {
-        //NOP
+        // NOP
     }
 
     override suspend fun listProcesses(): List<Process> {
@@ -68,7 +77,7 @@ object MockClient : Client {
                 pid = Random.nextUInt(1000u).toInt(),
                 ppid = Random.nextUInt(1000u).toInt(),
                 state = "R",
-                cmd = Cmd.Comm("/bin/sh/${alphabet.substring(it, it + 1)}")
+                cmd = Cmd.Comm("/bin/sh/${alphabet.substring(it, it + 1)}"),
             )
         }
     }
@@ -80,5 +89,4 @@ object MockClient : Client {
     override suspend fun setConfiguration(configuration: Configuration) {
         MockClient.configuration = configuration
     }
-
 }

--- a/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClientFactory.kt
+++ b/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClientFactory.kt
@@ -1,0 +1,10 @@
+package de.amosproj3.ziofa.client.mocks
+
+import de.amosproj3.ziofa.client.Client
+import de.amosproj3.ziofa.client.ClientFactory
+
+class MockClientFactory : ClientFactory {
+    override suspend fun connect(): Client {
+        return MockClient
+    }
+}

--- a/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClientFactory.kt
+++ b/frontend/client/src/main/java/de/amosproj3/ziofa/client/mocks/MockClientFactory.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
 package de.amosproj3.ziofa.client.mocks
 
 import de.amosproj3.ziofa.client.Client


### PR DESCRIPTION
This PR connects the client to the backend for the configuration screen
and the newly added process screen. It also two variants of the app, one
connecting to the real backend and on to a mocked backend for easy testing.
These variants have seperate Gradle tasks. The processes screen should be
combined with the configuration screen in the future.
For styling, a error screen and loading animation is introduced.

The ConfigurationViewModel & ConfigurationManager will be refactored in a coming sprint, as well as merging the process screen into the Configuration Screen as this is where it is needed.