### PR TITLE
[UI] add apps to processes, configuration menu, per process configuration

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(libs.accompanist.drawablepainter)
 
     implementation(project(":client"))
 

--- a/frontend/app/src/main/AndroidManifest.xml
+++ b/frontend/app/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@ SPDX-License-Identifier: MIT
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- not a problem since we are not publishing to Play Store -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
+
     <application
         android:name=".ZiofaApplication"
         android:allowBackup="true"

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
@@ -5,9 +5,12 @@
 package de.amosproj3.ziofa
 
 import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
 import de.amosproj3.ziofa.api.ConfigurationAccess
 import de.amosproj3.ziofa.api.ProcessListAccess
 import de.amosproj3.ziofa.bl.ConfigurationManager
+import de.amosproj3.ziofa.bl.PackageInformationProvider
 import de.amosproj3.ziofa.client.ClientFactory
 import de.amosproj3.ziofa.client.RustClientFactory
 import de.amosproj3.ziofa.ui.configuration.ConfigurationViewModel
@@ -24,11 +27,15 @@ import timber.log.Timber
 class ZiofaApplication : Application() {
 
     val appModule = module {
+        single<PackageManager> { get<Context>().packageManager }
+        single<PackageInformationProvider> { PackageInformationProvider(get()) }
         single<ClientFactory> { RustClientFactory("http://[::1]:50051") }
         single { ConfigurationManager(clientFactory = get()) } binds
             arrayOf(ConfigurationAccess::class, ProcessListAccess::class)
         viewModel { ConfigurationViewModel(configurationAccess = get()) }
-        viewModel { ProcessesViewModel(processListAccess = get()) }
+        viewModel {
+            ProcessesViewModel(processListAccess = get(), packageInformationProvider = get())
+        }
         viewModel { VisualizationViewModel(clientFactory = get()) }
     }
 

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/InstalledPackageInfo.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/InstalledPackageInfo.kt
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.api
+
+import android.graphics.drawable.Drawable
+
+data class InstalledPackageInfo(val displayName: String, val icon: Drawable)

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/bl/PackageInformationProvider.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/bl/PackageInformationProvider.kt
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.bl
+
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import de.amosproj3.ziofa.api.InstalledPackageInfo
+import timber.log.Timber
+
+class PackageInformationProvider(private val packageManager: PackageManager) {
+
+    private val installedPackages: Map<String, PackageInfo> by lazy {
+        packageManager.getInstalledPackages(PackageManager.GET_META_DATA).associateBy {
+            it.packageName
+        }
+    }
+
+    /**
+     * Returns the [InstalledPackageInfo] or null if:
+     * - an error occurred
+     * - the application info was not found
+     * - the package name was not found in the installed packages.
+     */
+    fun getPackageInfo(packageName: String): InstalledPackageInfo? {
+        return try {
+            installedPackages[packageName]?.applicationInfo?.let {
+                val displayName = packageManager.getApplicationLabel(it).toString()
+                val appIcon: Drawable = packageManager.getApplicationIcon(it)
+                InstalledPackageInfo(displayName, appIcon)
+            }
+        } catch (e: Exception) {
+            Timber.w(e.stackTraceToString())
+            return null
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/Routes.kt
@@ -7,8 +7,9 @@ package de.amosproj3.ziofa.ui
 /** Routes for the main navigation */
 enum class Routes {
     Visualize,
-    Configuration,
+    IndividualConfiguration,
     About,
     Home,
     Processes,
+    Configuration,
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationScreen.kt
@@ -28,7 +28,9 @@ fun ConfigurationScreen(
     modifier: Modifier = Modifier,
     viewModel: ConfigurationViewModel = koinViewModel(),
     onBack: () -> Unit = {},
+    pids: IntArray? = null,
 ) {
+
     Box(modifier = modifier.fillMaxSize()) {
         val screenState by remember { viewModel.configurationScreenState }.collectAsState()
         val configurationChangedByUser by remember { viewModel.changed }.collectAsState()
@@ -47,7 +49,7 @@ fun ConfigurationScreen(
                 if (configurationChangedByUser) {
                     SubmitFab(
                         modifier = Modifier.align(Alignment.BottomEnd),
-                        onClick = { viewModel.configurationSubmitted() },
+                        onClick = { viewModel.configurationSubmitted(pids) },
                     )
                 }
             }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationViewModel.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/ConfigurationViewModel.kt
@@ -58,7 +58,12 @@ class ConfigurationViewModel(val configurationAccess: ConfigurationAccess) : Vie
         _changed.update { true }
     }
 
-    fun configurationSubmitted() {
+    /**
+     * Submit the configuration to the backend.
+     *
+     * @param pids the affected Process IDs or null if the configuration should be set globally
+     */
+    fun configurationSubmitted(pids: IntArray?) {
         viewModelScope.launch {
             configurationAccess.submitConfiguration(checkedOptions.value.toConfiguration())
         }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ConfigurationMenu.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/ConfigurationMenu.kt
@@ -13,22 +13,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Devices
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import de.amosproj3.ziofa.ui.navigation.composables.MenuOptionData
 import de.amosproj3.ziofa.ui.navigation.composables.MenuOptions
 import de.amosproj3.ziofa.ui.navigation.data.Emoji
 
-/** Static home screen for navigation */
 @Composable
-@Preview(device = Devices.AUTOMOTIVE_1024p)
-fun HomeScreen(
+fun ConfigurationMenu(
     modifier: Modifier = Modifier,
-    toVisualize: () -> Unit = {},
-    toConfiguration: () -> Unit = {},
-    toAbout: () -> Unit = {},
+    toPresets: () -> Unit,
+    toProcesses: () -> Unit,
+    toGlobalConfiguration: () -> Unit,
 ) {
+
     Box(
         modifier =
             modifier
@@ -40,13 +37,21 @@ fun HomeScreen(
             MenuOptions(
                 menuOptions =
                     listOf(
-                        MenuOptionData(title = "Visualize", Emoji.Chart.unicode, toVisualize),
                         MenuOptionData(
-                            title = "Configuration",
-                            Emoji.Gear.unicode,
-                            toConfiguration,
+                            title = "Presets",
+                            logoEmoji = Emoji.Bookmarks.unicode,
+                            onClick = toPresets,
                         ),
-                        MenuOptionData(title = "About", Emoji.Info.unicode, toAbout),
+                        MenuOptionData(
+                            title = "Global",
+                            logoEmoji = Emoji.Globe.unicode,
+                            onClick = toGlobalConfiguration,
+                        ),
+                        MenuOptionData(
+                            title = "Per Process",
+                            logoEmoji = Emoji.MagnifyingGlass.unicode,
+                            onClick = toProcesses,
+                        ),
                     )
             )
         }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/composables/MenuOptions.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/composables/MenuOptions.kt
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.navigation.composables
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+
+data class MenuOptionData(val title: String, val logoEmoji: String, val onClick: () -> Unit)
+
+@Composable
+fun MenuOptions(modifier: Modifier = Modifier, menuOptions: List<MenuOptionData>) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        menuOptions.forEach {
+            MenuCardWithIcon(
+                text = it.title,
+                emoji = it.logoEmoji,
+                onClick = it.onClick,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+fun MenuCardWithIcon(
+    text: String,
+    emoji: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val modifierForCards =
+        modifier.aspectRatio(1f).clickable { onClick() }.focusable().padding(horizontal = 10.dp)
+
+    Card(
+        modifier = modifierForCards,
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        colors = CardDefaults.elevatedCardColors(),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                emoji,
+                fontSize = TextUnit(120f, TextUnitType.Sp),
+                modifier = Modifier.padding(bottom = 20.dp),
+            )
+            Text(text, fontSize = TextUnit(40f, TextUnitType.Sp))
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/data/Emoji.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/navigation/data/Emoji.kt
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.navigation.data
+
+enum class Emoji(val unicode: String) {
+    Chart("\uD83D\uDCCA"),
+    Gear("⚙\uFE0F"),
+    MagnifyingGlass("\uD83D\uDD0E"),
+    Info("ℹ\uFE0F"),
+    Globe("\uD83C\uDF10"),
+    Bookmarks("\uD83D\uDCD1"),
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessListEntry.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessListEntry.kt
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.processes
+
+import de.amosproj3.ziofa.api.InstalledPackageInfo
+import uniffi.shared.Process
+
+sealed class ProcessListEntry {
+
+    data class ProcessEntry(val process: Process) : ProcessListEntry()
+
+    data class ApplicationEntry(
+        val packageInfo: InstalledPackageInfo,
+        val processList: List<Process>,
+    ) : ProcessListEntry()
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesScreen.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesScreen.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -20,44 +22,61 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import de.amosproj3.ziofa.ui.processes.composables.EditButton
+import de.amosproj3.ziofa.ui.processes.composables.IconAndName
+import de.amosproj3.ziofa.ui.processes.composables.ProcessesHeader
 import org.koin.androidx.compose.koinViewModel
-import uniffi.shared.Cmd
 
 @Composable
-fun ProcessesScreen(modifier: Modifier, viewModel: ProcessesViewModel = koinViewModel()) {
+fun ProcessesScreen(
+    modifier: Modifier,
+    viewModel: ProcessesViewModel = koinViewModel(),
+    onClickEdit: (ProcessListEntry) -> Unit,
+) {
     Box(modifier = modifier.fillMaxSize()) {
         Column {
-            Row(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
-                Text(text = "CMD", modifier = Modifier.weight(1f))
-                Text(text = "State", modifier = Modifier.weight(1f))
-                Text(text = "PID", modifier = Modifier.weight(1f))
-                Text(text = "Parent PID", modifier = Modifier.weight(1f))
-            }
-
             val options by remember { viewModel.processesList }.collectAsState()
+
+            ProcessesHeader()
             LazyColumn(modifier = Modifier.padding(horizontal = 20.dp).fillMaxSize()) {
-                items(options) { option ->
-                    Row(
-                        modifier = Modifier.fillMaxSize(),
-                        horizontalArrangement = Arrangement.SpaceEvenly,
-                        verticalAlignment = Alignment.Top,
-                    ) {
-                        Text(text = option.cmd.toReadableString(), modifier = Modifier.weight(1f))
-                        Text(text = option.state, modifier = Modifier.weight(1f))
-                        Text(text = option.pid.toString(), modifier = Modifier.weight(1f))
-                        Text(text = option.ppid.toString(), modifier = Modifier.weight(1f))
-                    }
-                }
+                items(options) { option -> ProcessListRow(option, onClickEdit = onClickEdit) }
             }
         }
     }
 }
 
-fun Cmd?.toReadableString(): String {
-    this?.let {
-        return when (this) {
-            is Cmd.Comm -> this.v1
-            is Cmd.Cmdline -> this.v1.args.joinToString(" ")
+@Composable
+fun ProcessListRow(
+    option: ProcessListEntry,
+    onClickProcessInfo: (ProcessListEntry) -> Unit =
+        {}, // TODO implement modal with info about processes
+    onClickEdit: (ProcessListEntry) -> Unit = {},
+) {
+    Row(
+        modifier = Modifier.fillMaxSize().padding(vertical = 10.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        when (option) {
+            is ProcessListEntry.ProcessEntry -> {
+                IconAndName(option, modifier = Modifier.weight(1f))
+                Text(text = option.process.pid.toString(), modifier = Modifier.weight(1f))
+                Text(text = option.process.ppid.toString(), modifier = Modifier.weight(1f))
+            }
+
+            is ProcessListEntry.ApplicationEntry -> {
+                IconAndName(option, modifier = Modifier.weight(1f))
+                Text(
+                    text = option.processList.map { it.pid }.joinToString(","),
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = option.processList.map { it.ppid }.toSet().joinToString(","),
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
-    } ?: return "null"
+        EditButton(Modifier.weight(1f), onClick = { onClickEdit(option) })
+    }
+    HorizontalDivider(Modifier.height(5.dp))
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesViewModel.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/ProcessesViewModel.kt
@@ -7,13 +7,31 @@ package de.amosproj3.ziofa.ui.processes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import de.amosproj3.ziofa.api.ProcessListAccess
+import de.amosproj3.ziofa.bl.PackageInformationProvider
+import de.amosproj3.ziofa.ui.shared.toReadableString
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
-class ProcessesViewModel(processListAccess: ProcessListAccess) : ViewModel() {
+class ProcessesViewModel(
+    processListAccess: ProcessListAccess,
+    packageInformationProvider: PackageInformationProvider,
+) : ViewModel() {
     val processesList =
         processListAccess.processesList
-            .map { sortKey -> sortKey.sortedBy { it.pid } }
+            .map { processList -> processList.groupBy { it.cmd.toReadableString() } }
+            .map { packageProcessMap ->
+                packageProcessMap.entries.map {
+                    val packageNameOrOther = it.key
+                    val processList = it.value
+                    // TODO We probably should not retrieve the info of all packages everytime
+                    packageInformationProvider.getPackageInfo(packageNameOrOther)?.let {
+                        ProcessListEntry.ApplicationEntry(it, processList)
+                    } ?: ProcessListEntry.ProcessEntry(processList[0])
+                }
+            }
+            .map { uiEntryList ->
+                uiEntryList.sortedBy { if (it is ProcessListEntry.ApplicationEntry) -1 else 1 }
+            }
             .stateIn(viewModelScope, started = SharingStarted.Lazily, listOf())
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/composables/EditButton.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/composables/EditButton.kt
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.processes.composables
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun EditButton(modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
+    Box(modifier = modifier.clickable { onClick() }) {
+        Image(
+            imageVector = Icons.Filled.Edit,
+            contentDescription = "",
+            modifier = Modifier.align(Alignment.CenterEnd),
+        )
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/composables/IconAndName.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/composables/IconAndName.kt
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.processes.composables
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import de.amosproj3.ziofa.ui.processes.ProcessListEntry
+import de.amosproj3.ziofa.ui.shared.toReadableString
+
+@Composable
+fun IconAndName(option: ProcessListEntry.ApplicationEntry, modifier: Modifier = Modifier) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        val painter = rememberDrawablePainter(option.packageInfo.icon)
+        Image(painter = painter, contentDescription = "", modifier = Modifier.size(50.dp, 50.dp))
+        Spacer(modifier = Modifier.width(20.dp))
+        Text(text = option.packageInfo.displayName)
+    }
+}
+
+@Composable
+fun IconAndName(option: ProcessListEntry.ProcessEntry, modifier: Modifier = Modifier) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Image(
+            imageVector = Icons.Filled.Info,
+            contentDescription = "",
+            modifier = Modifier.size(50.dp, 50.dp),
+        )
+        Spacer(modifier = Modifier.width(20.dp))
+        Text(text = option.process.cmd.toReadableString(), modifier = modifier)
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/composables/ProcessesHeader.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/processes/composables/ProcessesHeader.kt
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.processes.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ProcessesHeader() {
+    Row(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
+        Text(text = "Name", modifier = Modifier.weight(1f))
+        Text(text = "PID(s)", modifier = Modifier.weight(1f))
+        Text(text = "Parent PID", modifier = Modifier.weight(1f))
+        Text(text = "", modifier = Modifier.weight(1f))
+    }
+    HorizontalDivider(Modifier.height(15.dp).background(MaterialTheme.colorScheme.primary))
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/shared/Helpers.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/shared/Helpers.kt
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.shared
+
+import de.amosproj3.ziofa.ui.processes.ProcessListEntry
+import uniffi.shared.Cmd
+
+fun Cmd?.toReadableString(): String {
+    this?.let {
+        return when (this) {
+            is Cmd.Comm -> this.v1
+            is Cmd.Cmdline -> this.v1.args.joinToString(" ")
+        }
+    } ?: return "null"
+}
+
+fun ProcessListEntry.getDisplayName(): String {
+    return when (this) {
+        is ProcessListEntry.ApplicationEntry -> this.packageInfo.displayName
+        is ProcessListEntry.ProcessEntry -> this.process.cmd.toReadableString()
+    }
+}
+
+fun ProcessListEntry.serializePIDs(): String {
+    return when (this) {
+        is ProcessListEntry.ApplicationEntry -> this.processList.map { it.pid }
+        is ProcessListEntry.ProcessEntry -> listOf(this.process.pid)
+    }.joinToString(",")
+}
+
+fun String.deserializePIDs(): IntArray {
+    return this.split(",").map { it.toInt() }.toIntArray()
+}
+
+fun IntArray.validPIDsOrNull(): IntArray? {
+    if (this.contains(-1)) {
+        return null
+    }
+    return this
+}

--- a/frontend/gradle/libs.versions.toml
+++ b/frontend/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 [versions]
+accompanistDrawablepainter = "0.36.0"
 activityCompose = "1.9.3"
 # @pin incompatible otherwise
 agp = "8.6.0"
@@ -24,6 +25,7 @@ versioncatalogueupdate = "0.8.5"
 vico = "2.0.0-beta.2"
 
 [libraries]
+accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
This PR groups processes to their packages application in the process screen. Additionaly, the configuration screen is split into preset, global and per process configuration. This way, we can configure eBPF programs either for individual processes, apps or globally.

New Configuration Menu:
![image](https://github.com/user-attachments/assets/a43a650a-63ca-475f-9465-414eecc5ffb7)

New combined apps and processes menu, clicking an entry will take you to the old configuration screen.
![image](https://github.com/user-attachments/assets/e0fc2ed2-f395-4776-b1e8-2b75d052a5fc)
