### PR TITLE
chore(eBPF) set the threshold for a blocking call individually per pid

### DIFF
--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/WriteEvent.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/WriteEvent.kt
@@ -23,6 +23,6 @@ sealed class WriteEvent(
         val pid: UInt,
         val tid: UInt,
         val beginTimestamp: ULong,
-        val durationMicros: ULong,
-    ) : WriteEvent(fd, pid, beginTimestamp, durationMicros)
+        val durationNanos: ULong,
+    ) : WriteEvent(fd, pid, beginTimestamp, durationNanos)
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/EventList.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/EventList.kt
@@ -39,7 +39,7 @@ fun EventList(events: List<WriteEvent>) {
                 when (event) {
                     is WriteEvent.SendMessageEvent -> {
                         Text(
-                            text = (event.durationMicros / 1_000u).toString(),
+                            text = (event.durationNanos / 1_000_000u).toString(),
                             modifier = Modifier.weight(1f),
                         )
                     }

--- a/frontend/client/src/main/java/de/amosproj3/ziofa/client/Client.kt
+++ b/frontend/client/src/main/java/de/amosproj3/ziofa/client/Client.kt
@@ -31,8 +31,8 @@ sealed class Event {
         val pid: UInt,
         val tid: UInt,
         val beginTimeStamp: ULong,
-        val fd: Int,
-        val durationMicroSec: ULong,
+        val fd: ULong,
+        val durationNanoSecs: ULong,
     ) : Event()
 }
 

--- a/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
+++ b/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
@@ -94,8 +94,8 @@ object RustClient : Client {
                 Event.SysSendmsg(
                     pid = 12345u,
                     tid = 1234u,
-                    fd = 125123123,
-                    durationMicroSec =
+                    fd = 125123123u,
+                    durationNanoSecs =
                         (System.currentTimeMillis() + Random.nextLong(1000)).toULong(),
                     beginTimeStamp = System.currentTimeMillis().toULong(),
                 )

--- a/frontend/client/src/real/java/de.amosproj3.ziofa.client/RustClient.kt
+++ b/frontend/client/src/real/java/de.amosproj3.ziofa.client/RustClient.kt
@@ -42,7 +42,7 @@ private fun uniffi.shared.Event.into() =
                 tid = d.v1.tid,
                 beginTimeStamp = d.v1.beginTimeStamp,
                 fd = d.v1.fd,
-                durationMicroSec = d.v1.durationMicroSec,
+                durationNanoSecs = d.v1.durationNanoSec,
             )
         null -> null
     }

--- a/rust/backend/common/src/lib.rs
+++ b/rust/backend/common/src/lib.rs
@@ -32,12 +32,12 @@ pub struct SysSendmsgCall {
     pub tid: u32,
     pub begin_time_stamp: u64,
     pub fd: i32,
-    pub duration_micro_sec: u64, // in microseconds
+    pub duration_nano_sec: u64, // in nanoseconds
 }
 
 impl SysSendmsgCall {
-    pub fn new(pid: u32, tid: u32, begin_time_stamp: u64, fd: i32, duration_micro_sec: u64) -> Self {
-        Self { pid, tid, begin_time_stamp, fd, duration_micro_sec }
+    pub fn new(pid: u32, tid: u32, begin_time_stamp: u64, fd: i32, duration_nano_sec: u64) -> Self {
+        Self { pid, tid, begin_time_stamp, fd, duration_nano_sec }
     }
 }
 

--- a/rust/backend/common/src/lib.rs
+++ b/rust/backend/common/src/lib.rs
@@ -31,12 +31,12 @@ pub struct SysSendmsgCall {
     pub pid: u32,
     pub tid: u32,
     pub begin_time_stamp: u64,
-    pub fd: i32,
+    pub fd: u64,
     pub duration_nano_sec: u64, // in nanoseconds
 }
 
 impl SysSendmsgCall {
-    pub fn new(pid: u32, tid: u32, begin_time_stamp: u64, fd: i32, duration_nano_sec: u64) -> Self {
+    pub fn new(pid: u32, tid: u32, begin_time_stamp: u64, fd: u64, duration_nano_sec: u64) -> Self {
         Self { pid, tid, begin_time_stamp, fd, duration_nano_sec }
     }
 }

--- a/rust/backend/daemon/src/collector.rs
+++ b/rust/backend/daemon/src/collector.rs
@@ -54,7 +54,7 @@ impl CollectFromMap for SysSendmsgCollect {
                 tid: data.tid,
                 begin_time_stamp: data.begin_time_stamp,
                 fd: data.fd,
-                duration_micro_sec: data.duration_micro_sec
+                duration_nano_sec: data.duration_nano_sec
             }))
         })
     }

--- a/rust/backend/daemon/src/features.rs
+++ b/rust/backend/daemon/src/features.rs
@@ -65,7 +65,7 @@ impl SysSendmsgFeature {
     }
     
     fn update_pids(&mut self, ebpf: &mut Ebpf, pids: &[u32]) -> Result<(), EbpfError> {
-        let mut pids_to_track: HashMap<_, u32, u32> = ebpf.map_mut("PIDS_TO_TRACK")
+        let mut pids_to_track: HashMap<_, u32, u64> = ebpf.map_mut("PIDS_TO_TRACK")
             .ok_or(EbpfError::MapError(
                 aya::maps::MapError::InvalidName {
                     name: "PIDS_TO_TRACK".to_string(),

--- a/rust/backend/ebpf/src/sys_sendmsg.rs
+++ b/rust/backend/ebpf/src/sys_sendmsg.rs
@@ -18,7 +18,7 @@ static SYS_SENDMSG_TIMESTAMPS: HashMap<u64, SysSendmsgIntern> = HashMap::with_ma
 
 struct SysSendmsgIntern {
     begin_time_stamp: u64,
-    fd: i32,
+    fd: u64,
 }
 
 #[tracepoint]
@@ -26,7 +26,7 @@ pub fn sys_enter_sendmsg(ctx: TracePointContext) -> u32 {
     let id = generate_id(ctx.pid(), ctx.tgid());
 
     let begin_time_stamp;
-    let fd: i32;
+    let fd: u64;
     unsafe {
         fd = match ctx.read_at(16) {
             Ok(arg) => arg,

--- a/rust/shared/proto/ziofa.proto
+++ b/rust/shared/proto/ziofa.proto
@@ -67,6 +67,6 @@ message SysSendmsgEvent {
     uint32 pid = 1;
     uint32 tid = 2;
     uint64 begin_time_stamp = 3;
-    int32 fd = 4;
+    uint64 fd = 4;
     uint64 duration_micro_sec = 5;
 }

--- a/rust/shared/proto/ziofa.proto
+++ b/rust/shared/proto/ziofa.proto
@@ -68,5 +68,5 @@ message SysSendmsgEvent {
     uint32 tid = 2;
     uint64 begin_time_stamp = 3;
     uint64 fd = 4;
-    uint64 duration_micro_sec = 5;
+    uint64 duration_nano_sec = 5;
 }


### PR DESCRIPTION
do this by inserting in the `PIDS_TO_TRACK` map with key: `pid` and value: `duration_in_microseconds`.
This PR also fixes am small bug that could occur if you remove a pid from the hashmap.