### PR TITLE
Finding Symbols from shared libraries

### DIFF
--- a/frontend/app/src/main/java/de/amosproj3/ziofa/bl/configuration/UProbeManager.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/bl/configuration/UProbeManager.kt
@@ -42,7 +42,7 @@ class UProbeManager(private val clientFactory: ClientFactory) : SymbolsAccess {
                                     .onEach { Timber.i("Requesting symbols for odex file $it") }
                                     .flatMapMerge { odexFile ->
                                         client
-                                            .getSymbols(odexFilePath = odexFile)
+                                            .getSymbols(filePath = odexFile)
                                             .filter {
                                                 it.method
                                                     .lowercase()

--- a/frontend/client/src/main/java/de/amosproj3/ziofa/client/Client.kt
+++ b/frontend/client/src/main/java/de/amosproj3/ziofa/client/Client.kt
@@ -91,7 +91,9 @@ interface Client {
 
     suspend fun getOdexFiles(pid: UInt): Flow<String>
 
-    suspend fun getSymbols(odexFilePath: String): Flow<Symbol>
+    suspend fun getSoFiles(pid: UInt): Flow<String>
+
+    suspend fun getSymbols(filePath: String): Flow<Symbol>
 
     suspend fun initStream(): Flow<Event>
 }

--- a/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
+++ b/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
@@ -135,7 +135,18 @@ object RustClient : Client {
         emit("/system_ext/framework/oat/x86_64/androidx.window.extensions.odex")
     }
 
-    override suspend fun getSymbols(odexFilePath: String): Flow<Symbol> = flow {
+    override suspend fun getSoFiles(pid: UInt): Flow<String> = flow {
+        emit("/system/lib64/liblog.so")
+        emit("/vendor/lib64/libdrm.so")
+        emit("/vendor/lib64/android.hardware.graphics.mapper@3.0.so")
+        emit("/system/lib64/android.hardware.power-V5-ndk.so")
+        emit("/system/lib64/android.hardware.graphics.mapper@2.0.so")
+        emit("/system/lib64/android.hardware.media.c2@1.2.so")
+
+        emit("/system/lib64/android.hardware.renderscript@1.0.so")
+    }
+
+    override suspend fun getSymbols(filePath: String): Flow<Symbol> = flow {
         emit(
             Symbol(
                 method =

--- a/frontend/client/src/real/java/de.amosproj3.ziofa.client/RustClient.kt
+++ b/frontend/client/src/real/java/de.amosproj3.ziofa.client/RustClient.kt
@@ -131,8 +131,11 @@ class RustClient(private val inner: uniffi.client.Client) : Client {
     override suspend fun getOdexFiles(pid: UInt): Flow<String> =
         inner.getOdexFilesFlow(pid).mapNotNull { it.into().name }
 
-    override suspend fun getSymbols(odexFilePath: String): Flow<Symbol> =
-        inner.getSymbolFlow(odexFilePath).mapNotNull { it.into() }
+    override suspend fun getSoFiles(pid: UInt): Flow<String> =
+        inner.getSoFilesFlow(pid).mapNotNull { it.into().name }
+
+    override suspend fun getSymbols(filePath: String): Flow<Symbol> =
+        inner.getSymbolFlow(filePath).mapNotNull { it.into() }
 
     override suspend fun initStream(): Flow<Event> = inner.initStreamFlow().mapNotNull { it.into() }
 }
@@ -182,8 +185,16 @@ fun uniffi.client.Client.getOdexFilesFlow(pid: UInt) = flow {
     }
 }
 
-fun uniffi.client.Client.getSymbolFlow(odexFilePath: String) = flow {
-    getSymbols(odexFilePath).use { stream ->
+fun uniffi.client.Client.getSoFilesFlow(pid: UInt) = flow {
+    getOdexFiles(pid).use { stream ->
+        while (true) {
+            stream.next()?.also { file -> emit(file) } ?: break
+        }
+    }
+}
+
+fun uniffi.client.Client.getSymbolFlow(filePath: String) = flow {
+    getSymbols(filePath).use { stream ->
         while (true) {
             stream.next()?.also { symbol -> emit(symbol) } ?: break
         }

--- a/rust/backend/daemon/src/server.rs
+++ b/rust/backend/daemon/src/server.rs
@@ -124,7 +124,7 @@ impl Ziofa for ZiofaImpl {
         tokio::spawn(async move {
             let mut symbol_handler_guard = symbol_handler.lock().await;
             // TODO Error Handling
-            let odex_paths = match symbol_handler_guard.get_odex_paths(pid) {
+            let odex_paths = match symbol_handler_guard.get_paths(pid, ".odex") {
                 Ok(paths) => paths,
                 Err(e) => {
                     tx.send(Err(Status::from(e)))
@@ -161,7 +161,7 @@ impl Ziofa for ZiofaImpl {
         tokio::spawn(async move {
             let mut symbol_handler_guard = symbol_handler.lock().await;
             // TODO Error Handling
-            let odex_paths = match symbol_handler_guard.get_so_paths(pid) {
+            let odex_paths = match symbol_handler_guard.get_paths(pid, ".so") {
                 Ok(paths) => paths,
                 Err(e) => {
                     tx.send(Err(Status::from(e)))

--- a/rust/backend/daemon/src/server.rs
+++ b/rust/backend/daemon/src/server.rs
@@ -190,8 +190,8 @@ impl Ziofa for ZiofaImpl {
         request: Request<GetSymbolsRequest>,
     ) -> Result<Response<Self::GetSymbolsStream>, Status> {
         let process_request = request.into_inner();
-        let odex_file_path_string = process_request.odex_file_path;
-        let odex_file_path = PathBuf::from(odex_file_path_string);
+        let file_path_string = process_request.file_path;
+        let file_path = PathBuf::from(file_path_string);
 
         let (tx, rx) = mpsc::channel(4);
 
@@ -200,7 +200,7 @@ impl Ziofa for ZiofaImpl {
         tokio::spawn(async move {
             let mut symbol_handler_guard = symbol_handler.lock().await;
 
-            let symbol = match symbol_handler_guard.get_symbols(&odex_file_path).await {
+            let symbol = match symbol_handler_guard.get_symbols(&file_path).await {
                 Ok(symbol) => symbol,
                 Err(e) => {
                     tx.send(Err(Status::from(e)))

--- a/rust/backend/daemon/src/symbols.rs
+++ b/rust/backend/daemon/src/symbols.rs
@@ -93,16 +93,8 @@ impl SymbolHandler {
         // TODO: Remove old/long unused paths from cache
     }
 
-    pub fn get_odex_paths(&mut self, pid: u32) -> Result<&HashSet<PathBuf>, SymbolError> {
-        self.load_map_paths(pid, ".odex")?;
-
-        self.files
-            .get(&pid)
-            .ok_or(SymbolError::SymbolPathsNotLoaded { pid })
-    }
-
-    pub fn get_so_paths(&mut self, pid: u32) -> Result<&HashSet<PathBuf>, SymbolError> {
-        self.load_map_paths(pid, ".so")?;
+    pub fn get_paths(&mut self, pid: u32, extension: &str) -> Result<&HashSet<PathBuf>, SymbolError> {
+        self.load_map_paths(pid, extension)?;
 
         self.files
             .get(&pid)

--- a/rust/client/src/bin/cli.rs
+++ b/rust/client/src/bin/cli.rs
@@ -74,7 +74,7 @@ enum Commands {
     Symbols {
         /// Path to the .odex file which should be crawled
         #[arg(short, long)]
-        odex_file: String,
+        file: String,
 
         /// Only output number of symbols
         #[arg(short, long)]
@@ -172,8 +172,8 @@ async fn get_so_files(client: &mut Client, pid: u32, silent: bool) -> Result<()>
     Ok(())
 }
 
-async fn get_symbols(client: &mut Client, odex_file: String, silent: bool) -> Result<()> {
-    let mut stream = client.get_symbols(odex_file).await?;
+async fn get_symbols(client: &mut Client, file: String, silent: bool) -> Result<()> {
+    let mut stream = client.get_symbols(file).await?;
     let mut count: u32 = 0;
 
     while let Some(Ok(next)) = stream.next().await {
@@ -195,6 +195,7 @@ async fn get_symbols(client: &mut Client, odex_file: String, silent: bool) -> Re
 pub async fn main() -> anyhow::Result<()> {
     let args: Args = Args::parse();
 
+    println!("Trying to connect to {}", args.addr);
     let mut client = Client::connect(args.addr.to_owned()).await?;
 
     match args.cmd {
@@ -217,8 +218,8 @@ pub async fn main() -> anyhow::Result<()> {
         Commands::Odex { pid, silent } => {
             get_odex_files(&mut client, pid, silent).await?;
         }
-        Commands::Symbols { odex_file, silent } => {
-            get_symbols(&mut client, odex_file, silent).await?;
+        Commands::Symbols { file, silent } => {
+            get_symbols(&mut client, file, silent).await?;
         }
         Commands::So { pid, silent } => {
             get_so_files(&mut client, pid, silent).await?;

--- a/rust/client/src/bindings.rs
+++ b/rust/client/src/bindings.rs
@@ -59,6 +59,21 @@ impl OdexFileStream {
 }
 
 #[derive(uniffi::Object)]
+struct SoFileStream(Mutex<Pin<Box<dyn Stream<Item = Result<StringResponse>> + Send>>>);
+
+#[uniffi::export(async_runtime = "tokio")]
+impl SoFileStream {
+    pub async fn next(&self) -> Result<Option<StringResponse>> {
+        let mut guard = self.0.lock().await;
+        match guard.next().await {
+            Some(Ok(x)) => Ok(Some(x)),
+            Some(Err(e)) => Err(e),
+            None => Ok(None),
+        }
+    }
+}
+
+#[derive(uniffi::Object)]
 struct SymbolStream(Mutex<Pin<Box<dyn Stream<Item = Result<Symbol>> + Send>>>);
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -160,6 +175,16 @@ impl Client {
             .map(|x| x.map_err(ClientError::from));
 
         Ok(OdexFileStream(Mutex::new(Box::pin(stream))))
+    }
+
+    pub async fn get_so_files(&self, pid: u32) -> Result<SoFileStream> {
+        let mut guard = self.0.lock().await;
+        let stream = guard
+            .get_so_files(pid)
+            .await?
+            .map(|x| x.map_err(ClientError::from));
+
+        Ok(SoFileStream(Mutex::new(Box::pin(stream))))
     }
 
     pub async fn get_symbols(&self, odex_file: String) -> Result<SymbolStream> {

--- a/rust/client/src/client.rs
+++ b/rust/client/src/client.rs
@@ -127,6 +127,18 @@ impl Client {
             .map(|s| Ok(s?)))
     }
 
+    pub async fn get_so_files(
+        &mut self,
+        pid: u32,
+    ) -> Result<impl Stream<Item = Result<StringResponse>>> {
+        Ok(self
+            .ziofa
+            .get_so_files(PidMessage { pid })
+            .await?
+            .into_inner()
+            .map(|s| Ok(s?)))
+    }
+
     pub async fn get_symbols(
         &mut self,
         odex_file_path: String,

--- a/rust/client/src/client.rs
+++ b/rust/client/src/client.rs
@@ -141,11 +141,11 @@ impl Client {
 
     pub async fn get_symbols(
         &mut self,
-        odex_file_path: String,
+        file_path: String,
     ) -> Result<impl Stream<Item = Result<Symbol>>> {
         Ok(self
             .ziofa
-            .get_symbols(GetSymbolsRequest { odex_file_path })
+            .get_symbols(GetSymbolsRequest { file_path })
             .await?
             .into_inner()
             .map(|s| Ok(s?)))

--- a/rust/shared/proto/ziofa.proto
+++ b/rust/shared/proto/ziofa.proto
@@ -21,6 +21,7 @@ service Ziofa {
     rpc InitStream(google.protobuf.Empty) returns (stream Event) {}      // all Responses genereated by the ebpf-programms are send via this stream
 
     rpc GetOdexFiles(PidMessage) returns (stream StringResponse) {}
+    rpc GetSoFiles(PidMessage) returns (stream StringResponse) {}
     rpc GetSymbols(GetSymbolsRequest) returns (stream Symbol) {}
 }
 

--- a/rust/shared/proto/ziofa.proto
+++ b/rust/shared/proto/ziofa.proto
@@ -30,7 +30,7 @@ message StringResponse {
 }
 
 message GetSymbolsRequest {
-    string odex_file_path = 2;
+    string file_path = 2;
 }
 
 message Symbol {


### PR DESCRIPTION
This mainly consists of adapted code. There is a major rework ahead of us regarding the integration of a database, thus I didn't bother to simplify the odex and so symbol getting any further. 

The feature can be tested via the cli client:
```
# get all .so files of pid
$ cargo run --bin client --features cli so -p <pid>

# get all symbols out of that .so file
$ cargo run --bin client --features cli symbols -f <path>
```

Closes #116 
Part of #19 