### PR TITLE
Daemon part of FD tracking

### DIFF
--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/utils/Constants.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/configuration/utils/Constants.kt
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
+// SPDX-FileCopyrightText: 2025 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -6,4 +7,4 @@ package de.amosproj3.ziofa.ui.configuration.utils
 
 import de.amosproj3.ziofa.client.Configuration
 
-val EMPTY_CONFIGURATION = Configuration(null, null, listOf(), null, null, null)
+val EMPTY_CONFIGURATION = Configuration(null, null, listOf(), null, null, null, null)

--- a/frontend/client/src/main/java/de/amosproj3/ziofa/client/Client.kt
+++ b/frontend/client/src/main/java/de/amosproj3/ziofa/client/Client.kt
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
-// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
+// SPDX-FileCopyrightText: 2025 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -14,6 +14,7 @@ data class Configuration(
     val jniReferences: JniReferencesConfig?,
     val sysSigquit: SysSigquitConfig?,
     val gc: GcConfig?,
+    val sysFdTracking: SysFdTrackingConfig?,
 )
 
 data class VfsWriteConfig(val entries: Map<UInt, ULong>)
@@ -27,6 +28,8 @@ data class JniReferencesConfig(val pids: List<UInt>)
 data class SysSigquitConfig(val pids: List<UInt>)
 
 data object GcConfig
+
+data class SysFdTrackingConfig(val pids: List<UInt>)
 
 sealed class Event {
     data class VfsWrite(
@@ -80,6 +83,18 @@ sealed class Event {
         var freedLosBytes: Long,
         var pauseTimes: List<ULong>,
     ) : Event()
+
+    data class SysFdTracking(
+        val pid: UInt,
+        val tid: UInt,
+        val timeStamp: ULong,
+        val fdAction: SysFdAction?,
+    ) : Event() {
+        enum class SysFdAction {
+            Created,
+            Destroyed,
+        }
+    }
 }
 
 data class Process(val pid: UInt, val ppid: UInt, val state: String, val cmd: Command?)

--- a/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
+++ b/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
 // SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
-// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
+// SPDX-FileCopyrightText: 2025 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -23,6 +23,7 @@ object RustClient : Client {
             jniReferences = JniReferencesConfig(pids = listOf()),
             sysSigquit = SysSigquitConfig(pids = listOf()),
             gc = GcConfig,
+            sysFdTracking = SysFdTrackingConfig(pids = listOf()),
         )
 
     override suspend fun serverCount(): Flow<UInt> = flow {
@@ -140,6 +141,16 @@ object RustClient : Client {
                         tid = 1234u,
                         timeStamp = 12312412u,
                         targetPid = 12874u,
+                    )
+                )
+            }
+            configuration.sysFdTracking?.pids?.forEach {
+                emit(
+                    Event.SysFdTracking(
+                        pid = it,
+                        tid = 1234u,
+                        timeStamp = 12312412u,
+                        fdAction = Event.SysFdTracking.SysFdAction.Created,
                     )
                 )
             }

--- a/frontend/client/src/real/java/de.amosproj3.ziofa.client/RustClient.kt
+++ b/frontend/client/src/real/java/de.amosproj3.ziofa.client/RustClient.kt
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
-// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
+// SPDX-FileCopyrightText: 2025 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -12,9 +12,11 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import uniffi.client.jniMethodNameFromI32
+import uniffi.client.sysFdActionFromI32
 import uniffi.shared.Cmd
 import uniffi.shared.EventData
 import uniffi.shared.JniMethodName
+import uniffi.shared.SysFdAction
 
 private fun uniffi.shared.Process.into() =
     Process(
@@ -86,6 +88,18 @@ private fun uniffi.shared.Event.into() =
                 freedLosBytes = d.v1.freedLosBytes,
                 pauseTimes = d.v1.pauseTimes,
             )
+        is EventData.SysFdTracking ->
+            Event.SysFdTracking(
+                pid = d.v1.pid,
+                tid = d.v1.tid,
+                timeStamp = d.v1.timeStamp,
+                fdAction =
+                    when (sysFdActionFromI32(d.v1.fdAction)) {
+                        SysFdAction.CREATED -> Event.SysFdTracking.SysFdAction.Created
+                        SysFdAction.DESTROYED -> Event.SysFdTracking.SysFdAction.Destroyed
+                        SysFdAction.UNDEFINED -> null
+                    },
+            )
         null -> null
     }
 
@@ -105,6 +119,7 @@ private fun uniffi.shared.Configuration.into() =
         jniReferences = jniReferences?.let { JniReferencesConfig(pids = it.pids) },
         sysSigquit = sysSigquit?.let { SysSigquitConfig(pids = it.pids) },
         gc = gc?.let { GcConfig },
+        sysFdTracking = sysFdTracking?.let { SysFdTrackingConfig(pids = it.pids) },
     )
 
 private fun Configuration.into() =
@@ -123,6 +138,7 @@ private fun Configuration.into() =
         jniReferences = jniReferences?.let { uniffi.shared.JniReferencesConfig(it.pids) },
         sysSigquit = sysSigquit?.let { uniffi.shared.SysSigquitConfig(it.pids) },
         gc = gc?.let { uniffi.shared.GcConfig() },
+        sysFdTracking = sysFdTracking?.let { uniffi.shared.SysFdTrackingConfig(it.pids) },
     )
 
 private fun uniffi.shared.StringResponse.into() = StringResponse(name)

--- a/rust/backend/common/src/lib.rs
+++ b/rust/backend/common/src/lib.rs
@@ -4,7 +4,7 @@
 // SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
 // SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
 // SPDX-FileCopyrightText: 2025 Tom Weisshuhn <tom.weisshuhn@fau.de>
-// SPDX-FileCopyrightText: 2025 Felix Hilgers <felix.hilgers@fau.de>
+// SPDX-FileCopyrightText: 2025 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -41,6 +41,12 @@ impl TryFromRaw for SysSigquitCall {
 }
 
 impl TryFromRaw for SysGcCall {
+    fn try_from_raw(raw: &[u8]) -> Result<Self, CheckedCastError> {
+        Ok(*bytemuck::checked::try_from_bytes(raw)?)
+    }
+}
+
+impl TryFromRaw for SysFdActionCall {
     fn try_from_raw(raw: &[u8]) -> Result<Self, CheckedCastError> {
         Ok(*bytemuck::checked::try_from_bytes(raw)?)
     }

--- a/rust/backend/daemon/src/collector/supervisor.rs
+++ b/rust/backend/daemon/src/collector/supervisor.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
+// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -23,6 +24,7 @@ enum CollectorT {
     JniCall,
     SysSigquit,
     Gc,
+    SysFdTracking,
 }
 
 pub struct CollectorSupervisor;
@@ -50,7 +52,7 @@ impl CollectorRefs {
         self.collectors.remove(cell)
     }
     async fn start_all(&mut self, registry: &EbpfEventRegistry, event_actor: &ActorRef<Event>, supervisor: &ActorCell) -> Result<(), ActorProcessingErr> {
-        for who in [CollectorT::VfsWrite, CollectorT::SysSendmsg, CollectorT::JniCall, CollectorT::SysSigquit, CollectorT::Gc] {
+        for who in [CollectorT::VfsWrite, CollectorT::SysSendmsg, CollectorT::JniCall, CollectorT::SysSigquit, CollectorT::Gc, CollectorT::SysFdTracking] {
             self.start(who, registry, event_actor, supervisor).await?;
         }
         Ok(())
@@ -62,6 +64,7 @@ impl CollectorRefs {
             CollectorT::JniCall => start_collector(registry.jni_ref_calls.clone(), event_actor.clone(), supervisor.clone()).await?,
             CollectorT::SysSigquit => start_collector(registry.sys_sigquit_events.clone(), event_actor.clone(), supervisor.clone()).await?,
             CollectorT::Gc => start_collector(registry.gc_events.clone(), event_actor.clone(), supervisor.clone()).await?,
+            CollectorT::SysFdTracking => start_collector(registry.sys_fd_tracking_events.clone(), event_actor.clone(), supervisor.clone()).await?,
         };
         self.collectors.insert(actor_ref.get_cell(), who);
         Ok(())

--- a/rust/backend/daemon/src/features/mod.rs
+++ b/rust/backend/daemon/src/features/mod.rs
@@ -10,6 +10,7 @@ mod vfs_write_feature;
 mod sys_sendmsg_feature;
 mod sys_sigquit_feature;
 mod garbage_collection_feature;
+mod sys_fd_tracking_feature;
 
 use std::collections::BTreeSet;
 use aya::EbpfError;
@@ -20,6 +21,7 @@ use shared::config::Configuration;
 use sys_sendmsg_feature::SysSendmsgFeature;
 use sys_sigquit_feature::SysSigquitFeature;
 use vfs_write_feature::VfsWriteFeature;
+use sys_fd_tracking_feature::SysFdTrackingFeature;
 
 use crate::{registry::{EbpfRegistry, OwnedHashMap, RegistryGuard}, symbols::actors::SymbolActorMsg};
 
@@ -38,6 +40,7 @@ pub struct Features {
     vfs_write_feature: VfsWriteFeature,
     jni_reference_feature: JNIReferencesFeature,
     gc_feature: GcFeature,
+    sys_fd_tracking_feature: SysFdTrackingFeature,
 }
 
 impl Features {
@@ -48,6 +51,7 @@ impl Features {
         let jni_reference_feature = JNIReferencesFeature::init(registry, Some(symbol_actor_ref));
         let sys_sigquit_feature = SysSigquitFeature::init(registry, None);
         let gc_feature = GcFeature::init(registry, None);
+        let sys_fd_tracking_feature = SysFdTrackingFeature::init(registry, None);
 
         Self {
             sys_sendmsg_feature,
@@ -55,6 +59,7 @@ impl Features {
             jni_reference_feature,
             sys_sigquit_feature,
             gc_feature,
+            sys_fd_tracking_feature,
         }
     }
 
@@ -68,6 +73,7 @@ impl Features {
         self.jni_reference_feature.apply( &config.jni_references).await?;
         self.sys_sigquit_feature.apply( &config.sys_sigquit).await?;
         self.gc_feature.apply( &config.gc).await?;
+        self.sys_fd_tracking_feature.apply( &config.sys_fd_tracking).await?;
 
         Ok(())
     }

--- a/rust/backend/daemon/src/features/sys_fd_tracking_feature.rs
+++ b/rust/backend/daemon/src/features/sys_fd_tracking_feature.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+#![allow(unused)]
+use crate::features::{update_pids, Feature};
+use crate::registry::{EbpfRegistry, OwnedHashMap, RegistryGuard};
+use crate::symbols::actors::{GetOffsetRequest, SymbolActorMsg};
+use aya::programs::trace_point::TracePointLink;
+use aya::programs::{TracePoint, UProbe};
+use aya::{programs::uprobe::UProbeLink, Ebpf, EbpfError};
+use ractor::{call, Actor, ActorRef, RactorErr};
+use shared::config::SysFdTrackingConfig;
+use tracing_subscriber::{registry, Registry};
+
+
+pub struct SysFdTrackingFeature {
+    trace_create_fd: RegistryGuard<TracePoint>,
+    trace_destroy_fd: RegistryGuard<TracePoint>,
+    trace_pids: RegistryGuard<OwnedHashMap<u32, u64>>,
+    trace_link_fd_open: Option<TracePointLink>,
+    trace_link_fd_close: Option<TracePointLink>,
+}
+
+impl SysFdTrackingFeature {
+    fn create(registry: &EbpfRegistry) -> Self {
+        Self {
+            trace_create_fd: registry.program.sys_create_fd.take(),
+            trace_destroy_fd: registry.program.sys_destroy_fd.take(),
+            trace_pids: registry.config.sys_fd_tracking_pids.take(),
+            trace_link_fd_open: None,
+            trace_link_fd_close: None,
+        }
+    }
+
+    pub async fn attach(&mut self) -> Result<(), EbpfError> {
+        // trace all syscalls which create a fd
+        if self.trace_link_fd_open.is_none() {
+            let link_id = self.trace_create_fd.attach("syscalls","open")?;
+            self.trace_link_fd_open = Some(self.trace_create_fd.take_link(link_id)?);
+        }
+
+        // trace all syscalls which destroy a fd
+        if self.trace_link_fd_close.is_none() {
+            let link_id = self.trace_destroy_fd.attach("syscalls","close")?;
+            self.trace_link_fd_close = Some(self.trace_destroy_fd.take_link(link_id)?);
+        }
+
+        Ok(())
+    }
+
+    pub fn detach(&mut self) {
+        let _ = self.trace_link_fd_open.take();
+        let _ = self.trace_link_fd_close.take();
+    }
+
+    fn update_pids(&mut self, pids: &[u32]) -> Result<(), EbpfError> {
+        // the general update_pids function for all features works with hashmaps, so the list is converted into a hashmap with keys always being 0
+        let pid_0_tuples: Vec<(u32, u64)> = pids.iter().map(|pid| (*pid, 0)).collect();
+        let pids_as_hashmap: std::collections::HashMap<u32, u64> =
+            std::collections::HashMap::from_iter(pid_0_tuples);
+
+        update_pids(&pids_as_hashmap, &mut self.trace_pids)
+    }
+}
+
+impl Feature for SysFdTrackingFeature {
+    type Config = SysFdTrackingConfig;
+
+    fn init(registry: &EbpfRegistry, _: Option<ActorRef<SymbolActorMsg>>) -> Self {
+        SysFdTrackingFeature::create(registry)
+    }
+    
+    async fn apply(&mut self, config: &Option<Self::Config>) -> Result<(), EbpfError> {
+        match config {
+            Some(config) => {
+                self.attach().await?;
+                self.update_pids(&config.pids)?;
+            }
+            None => {
+                self.detach();
+            }
+        }
+        Ok(())
+    }
+}

--- a/rust/backend/daemon/src/features/sys_fd_tracking_feature.rs
+++ b/rust/backend/daemon/src/features/sys_fd_tracking_feature.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
+// SPDX-FileCopyrightText: 2025 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -13,13 +13,36 @@ use ractor::{call, Actor, ActorRef, RactorErr};
 use shared::config::SysFdTrackingConfig;
 use tracing_subscriber::{registry, Registry};
 
-
 pub struct SysFdTrackingFeature {
     trace_create_fd: RegistryGuard<TracePoint>,
     trace_destroy_fd: RegistryGuard<TracePoint>,
     trace_pids: RegistryGuard<OwnedHashMap<u32, u64>>,
-    trace_link_fd_open: Option<TracePointLink>,
-    trace_link_fd_close: Option<TracePointLink>,
+
+    // list of syscalls taken from https://en.wikipedia.org/wiki/File_descriptor
+    trace_link_open: Option<TracePointLink>,
+    trace_link_creat: Option<TracePointLink>,
+    trace_link_socket: Option<TracePointLink>,
+    trace_link_accept: Option<TracePointLink>,
+    trace_link_socketpair: Option<TracePointLink>,
+    trace_link_pipe: Option<TracePointLink>,
+    trace_link_epoll_create: Option<TracePointLink>,
+    trace_link_signalfd: Option<TracePointLink>,
+    trace_link_eventfd: Option<TracePointLink>,
+    trace_link_timerfd_create: Option<TracePointLink>,
+    trace_link_memfd_create: Option<TracePointLink>,
+    trace_link_userfaultfd: Option<TracePointLink>,
+    trace_link_fanotify_init: Option<TracePointLink>,
+    trace_link_inotify_init: Option<TracePointLink>,
+    trace_link_clone: Option<TracePointLink>,
+    trace_link_pidfd_open: Option<TracePointLink>,
+    trace_link_open_by_handle_at: Option<TracePointLink>,
+
+    trace_link_close: Option<TracePointLink>,
+    trace_link_closefrom: Option<TracePointLink>,
+    trace_link_close_range: Option<TracePointLink>,
+    trace_link_dup: Option<TracePointLink>,
+
+    trace_link_openat: Option<TracePointLink>,
 }
 
 impl SysFdTrackingFeature {
@@ -28,30 +51,171 @@ impl SysFdTrackingFeature {
             trace_create_fd: registry.program.sys_create_fd.take(),
             trace_destroy_fd: registry.program.sys_destroy_fd.take(),
             trace_pids: registry.config.sys_fd_tracking_pids.take(),
-            trace_link_fd_open: None,
-            trace_link_fd_close: None,
+
+            trace_link_open: None,
+            trace_link_creat: None,
+            trace_link_socket: None,
+            trace_link_accept: None,
+            trace_link_socketpair: None,
+            trace_link_pipe: None,
+            trace_link_epoll_create: None,
+            trace_link_signalfd: None,
+            trace_link_eventfd: None,
+            trace_link_timerfd_create: None,
+            trace_link_memfd_create: None,
+            trace_link_userfaultfd: None,
+            trace_link_fanotify_init: None,
+            trace_link_inotify_init: None,
+            trace_link_clone: None,
+            trace_link_pidfd_open: None,
+            trace_link_open_by_handle_at: None,
+
+            trace_link_close: None,
+            trace_link_closefrom: None,
+            trace_link_close_range: None,
+            trace_link_dup: None,
+
+            trace_link_openat: None,
         }
     }
 
-    pub async fn attach(&mut self) -> Result<(), EbpfError> {
-        // trace all syscalls which create a fd
-        if self.trace_link_fd_open.is_none() {
-            let link_id = self.trace_create_fd.attach("syscalls","open")?;
-            self.trace_link_fd_open = Some(self.trace_create_fd.take_link(link_id)?);
-        }
+    fn try_attach_open(
+        trace_create_fd: &mut TracePoint,
+        syscall: &str,
+    ) -> Result<TracePointLink, EbpfError> {
+        let link_id = trace_create_fd.attach("syscalls", syscall)?;
+        Ok(trace_create_fd.take_link(link_id)?)
+    }
+    fn try_attach_destroy(
+        trace_destroy_fd: &mut TracePoint,
+        syscall: &str,
+    ) -> Result<TracePointLink, EbpfError> {
+        let link_id = trace_destroy_fd.attach("syscalls", syscall)?;
+        Ok(trace_destroy_fd.take_link(link_id)?)
+    }
 
-        // trace all syscalls which destroy a fd
-        if self.trace_link_fd_close.is_none() {
-            let link_id = self.trace_destroy_fd.attach("syscalls","close")?;
-            self.trace_link_fd_close = Some(self.trace_destroy_fd.take_link(link_id)?);
-        }
+    pub async fn attach(&mut self) -> Result<(), EbpfError> {
+        self.trace_link_open
+            .get_or_insert(Self::try_attach_open(&mut self.trace_create_fd, "open")?);
+        self.trace_link_creat
+            .get_or_insert(Self::try_attach_open(&mut self.trace_create_fd, "creat")?);
+        self.trace_link_socket
+            .get_or_insert(Self::try_attach_open(&mut self.trace_create_fd, "socket")?);
+        self.trace_link_accept
+            .get_or_insert(Self::try_attach_open(&mut self.trace_create_fd, "accept")?);
+        self.trace_link_socketpair
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "socketpair",
+            )?);
+        self.trace_link_pipe
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "pipe",
+            )?);
+        self.trace_link_epoll_create
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "epoll_create",
+            )?);
+        self.trace_link_signalfd
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "signalfd",
+            )?);
+        self.trace_link_eventfd
+            .get_or_insert(Self::try_attach_open(&mut self.trace_create_fd, "eventfd")?);
+        self.trace_link_timerfd_create
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "timerfd_create",
+            )?);
+        self.trace_link_memfd_create
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "memfd_create",
+            )?);
+        self.trace_link_userfaultfd
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "userfaultfd",
+            )?);
+        self.trace_link_fanotify_init
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "fanotify_init",
+            )?);
+        self.trace_link_inotify_init
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "inotify_init",
+            )?);
+        self.trace_link_clone
+            .get_or_insert(Self::try_attach_open(&mut self.trace_create_fd, "clone")?);
+        self.trace_link_pidfd_open
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "pidfd_open",
+            )?);
+        self.trace_link_open_by_handle_at
+            .get_or_insert(Self::try_attach_open(
+                &mut self.trace_create_fd,
+                "open_by_handle_at",
+            )?);
+
+        self.trace_link_close
+            .get_or_insert(Self::try_attach_destroy(
+                &mut self.trace_destroy_fd,
+                "close",
+            )?);
+        self.trace_link_closefrom
+            .get_or_insert(Self::try_attach_destroy(
+                &mut self.trace_destroy_fd,
+                "closefrom",
+            )?);
+        self.trace_link_close_range
+            .get_or_insert(Self::try_attach_destroy(
+                &mut self.trace_destroy_fd,
+                "close_range",
+            )?);
+        self.trace_link_dup.get_or_insert(Self::try_attach_open(
+            &mut self.trace_create_fd,
+            "dup",
+        )?);
+
+        self.trace_link_openat.get_or_insert(Self::try_attach_open(
+            &mut self.trace_create_fd,
+            "openat",
+        )?);
 
         Ok(())
     }
 
     pub fn detach(&mut self) {
-        let _ = self.trace_link_fd_open.take();
-        let _ = self.trace_link_fd_close.take();
+        let _ = self.trace_link_open.take();
+        let _ = self.trace_link_creat.take();
+        let _ = self.trace_link_socket.take();
+        let _ = self.trace_link_accept.take();
+        let _ = self.trace_link_socketpair.take();
+        let _ = self.trace_link_pipe.take();
+        let _ = self.trace_link_epoll_create.take();
+        let _ = self.trace_link_signalfd.take();
+        let _ = self.trace_link_eventfd.take();
+        let _ = self.trace_link_timerfd_create.take();
+        let _ = self.trace_link_memfd_create.take();
+        let _ = self.trace_link_userfaultfd.take();
+        let _ = self.trace_link_fanotify_init.take();
+        let _ = self.trace_link_inotify_init.take();
+        let _ = self.trace_link_clone.take();
+        let _ = self.trace_link_pidfd_open.take();
+        let _ = self.trace_link_open_by_handle_at.take();
+
+        let _ = self.trace_link_close.take();
+        let _ = self.trace_link_closefrom.take();
+        let _ = self.trace_link_close_range.take();
+        let _ = self.trace_link_dup.take();
+
+        let _ = self.trace_link_openat.take();
     }
 
     fn update_pids(&mut self, pids: &[u32]) -> Result<(), EbpfError> {
@@ -70,7 +234,7 @@ impl Feature for SysFdTrackingFeature {
     fn init(registry: &EbpfRegistry, _: Option<ActorRef<SymbolActorMsg>>) -> Self {
         SysFdTrackingFeature::create(registry)
     }
-    
+
     async fn apply(&mut self, config: &Option<Self::Config>) -> Result<(), EbpfError> {
         match config {
             Some(config) => {

--- a/rust/client/src/bin/cli.rs
+++ b/rust/client/src/bin/cli.rs
@@ -8,6 +8,7 @@ use clap::Subcommand;
 use client::Client;
 use client::ClientError;
 use shared::config::GcConfig;
+use shared::config::SysFdTrackingConfig;
 use shared::config::{Configuration, SysSendmsgConfig, VfsWriteConfig, JniReferencesConfig, SysSigquitConfig};
 use std::collections::HashMap;
 use tokio_stream::StreamExt;
@@ -114,7 +115,8 @@ async fn sendmsg(client: &mut Client, pid: u32) -> Result<()> {
             }),
             jni_references: None,
             sys_sigquit: Some(SysSigquitConfig { pids: vec![] }),
-            gc: Some(GcConfig { })
+            gc: Some(GcConfig { }),
+            sys_fd_tracking: Some(SysFdTrackingConfig { pids: vec![] }),
         })
         .await?;
 
@@ -139,7 +141,8 @@ async fn set_config(client: &mut Client) -> Result<()> {
             }),
             jni_references: Some(JniReferencesConfig { pids: vec![] }),
             sys_sigquit: Some(SysSigquitConfig { pids: vec![] }),
-            gc: Some(GcConfig { })
+            gc: Some(GcConfig { }),
+            sys_fd_tracking: Some(SysFdTrackingConfig { pids: vec![] }),
         })
         .await?;
     println!("Success");

--- a/rust/client/src/bindings.rs
+++ b/rust/client/src/bindings.rs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Felix Hilgers <felix.hilgers@fau.de>
-// SPDX-FileCopyrightText: 2024 Robin Seidl <robin.seidl@fau.de>
+// SPDX-FileCopyrightText: 2025 Robin Seidl <robin.seidl@fau.de>
 //
 // SPDX-License-Identifier: MIT
 
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 use tokio_stream::{Stream, StreamExt};
 use shared::ziofa::{Event, StringResponse, Symbol};
 use shared::ziofa::jni_references_event::JniMethodName;
+use shared::ziofa::sys_fd_tracking_event::SysFdAction;
 
 type Result<T> = core::result::Result<T, ClientError>;
 
@@ -213,4 +214,9 @@ impl Client {
 #[uniffi::export]
 pub fn jni_method_name_from_i32(num: i32) -> JniMethodName {
     JniMethodName::try_from(num).unwrap()
+}
+
+#[uniffi::export]
+pub fn sys_fd_action_from_i32(num: i32) -> SysFdAction {
+    SysFdAction::try_from(num).unwrap()
 }

--- a/rust/shared/build.rs
+++ b/rust/shared/build.rs
@@ -32,6 +32,8 @@ static UNIFFI_RECORDS: LazyLock<Vec<&str>> = LazyLock::new(|| {
             "SysSigquitConfig",
             "GcConfig",
             "GcEvent",
+            "SysFdTrackingConfig",
+            "SysFdTrackingEvent",
         ]
     } else {
         vec![]
@@ -40,7 +42,7 @@ static UNIFFI_RECORDS: LazyLock<Vec<&str>> = LazyLock::new(|| {
 
 static UNIFFI_ENUMS: LazyLock<Vec<&str>> = LazyLock::new(|| {
     if cfg!(feature = "uniffi") {
-        vec!["Process.cmd", "Event.event_data", "JniReferencesEvent.JniMethodName"]
+        vec!["Process.cmd", "Event.event_data", "JniReferencesEvent.JniMethodName", "SysFdTrackingEvent.SysFdAction"]
     } else {
         vec![]
     }

--- a/rust/shared/proto/config.proto
+++ b/rust/shared/proto/config.proto
@@ -24,6 +24,7 @@ message Configuration {
   optional SysSigquitConfig sys_sigquit = 4;
   repeated UprobeConfig uprobes = 5;
   optional GcConfig gc = 6;
+  optional SysFdTrackingConfig sys_fd_tracking = 7;
 }
 
 message VfsWriteConfig {
@@ -43,3 +44,7 @@ message SysSigquitConfig {
 }
 
 message GcConfig { }
+
+message SysFdTrackingConfig {
+  repeated uint32 pids = 1;
+}

--- a/rust/shared/proto/ziofa.proto
+++ b/rust/shared/proto/ziofa.proto
@@ -149,3 +149,15 @@ message GcEvent {
     int64 freed_los_bytes = 11;
     repeated uint64 pause_times = 12;
 }
+
+message SysFdTrackingEvent {
+    enum SysFdAction {
+        Undefined = 0;
+        Created = 1;
+        Destroyed = 2;
+    }
+    uint32 pid = 1;
+    uint32 tid = 2;
+    uint64 time_stamp = 3;
+    SysFdAction fd_action = 4;
+}

--- a/rust/shared/proto/ziofa.proto
+++ b/rust/shared/proto/ziofa.proto
@@ -95,6 +95,7 @@ message Event {
         JniReferencesEvent jni_references = 3;
         SysSigquitEvent sys_sigquit = 4;
         GcEvent gc = 5;
+        SysFdTrackingEvent sys_fd_tracking = 6;
     }
 }
 


### PR DESCRIPTION
Adds the daemon part of fd tracking. This includes the proto specs, the feature, the collector, the client bindings and the necessary frontend classes.

Bases on #217 so wait until that's merged and change target branch

Closes #207 