### PR TITLE
[UI] Add overlay mode for time series

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,6 +28,24 @@ To automatically update all dependencies, run
 Format `./gradlew combinedFormat` <br/>
 Check: `./gradlew ktfmtCheck`
 
+## Installing for overlay mode
+Overlay mode on AAOS requires elevated priviledges (priv-app + a runtime permission)
+* `./gradlew assemble`
+* `adb root`
+* `adb remount`
+* `adb reboot`
+* `adb remount`
+* `adb shell mkdir /system/priv-app/ziofa`
+* `adb push app/build/outputs/apk/mock/debug/app-mock-debug.apk /system/priv-app/ziofa`
+* `adb shell sync`
+* `adb shell reboot`
+* `adb root`
+* `adb push`
+* `adb shell pm grant de.amosproj3.ziofa android.permission.SYSTEM_ALERT_WINDOW`
+* `adb shell pm grant --user 10 de.amosproj3.ziofa android.permission.SYSTEM_ALERT_WINDOW`
+
+You only need to do this the first time, afterwards you can use the normal install method. 
+
 ## Troubleshooting
 ### The frontend crashes
 Make sure the backend is running or that you are running a mocked version.

--- a/frontend/app/src/main/AndroidManifest.xml
+++ b/frontend/app/src/main/AndroidManifest.xml
@@ -10,8 +10,12 @@ SPDX-License-Identifier: MIT
     xmlns:tools="http://schemas.android.com/tools">
 
     <!-- not a problem since we are not publishing to Play Store -->
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
 
     <application
         android:name=".ZiofaApplication"
@@ -26,13 +30,16 @@ SPDX-License-Identifier: MIT
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.ZIOFA">
+            android:theme="@style/Theme.AppCompat">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".OverlayService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/OverlayService.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/OverlayService.kt
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa
+
+import android.app.Service
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.os.IBinder
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import de.amosproj3.ziofa.shared.OVERLAY_POSITION_EXTRA
+import de.amosproj3.ziofa.ui.overlay.OverlayLifecycleOwner
+import de.amosproj3.ziofa.ui.overlay.OverlayRoot
+import de.amosproj3.ziofa.ui.visualization.data.OverlayPosition
+import timber.log.Timber
+
+class OverlayService : Service() {
+
+    class OverlayViewModelStoreOwner : ViewModelStoreOwner {
+        override val viewModelStore: ViewModelStore =
+            ViewModelStore().also { Timber.i("created viewmodel store $it") }
+    }
+
+    private val layoutParams =
+        WindowManager.LayoutParams(
+            /* w = */ WindowManager.LayoutParams.WRAP_CONTENT,
+            /* h = */ WindowManager.LayoutParams.WRAP_CONTENT,
+            /* _type = */ WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+            /* _flags = */ WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            /* _format = */ PixelFormat.TRANSLUCENT,
+        )
+
+    private val windowManager by lazy { getSystemService(WINDOW_SERVICE) as WindowManager }
+    private val lifecycleOwner by lazy { OverlayLifecycleOwner() }
+
+    private var activeOverlay: View? = null
+
+    override fun onCreate() {
+        Timber.i("onCreate()")
+        super.onCreate()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Timber.i("onStartCommand")
+        setTheme(R.style.Theme_ZIOFA)
+        layoutParams.applyOverlayPositionAsGravity(intent)
+        showOverlay()
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    private fun showOverlay() {
+        val composeView = createComposeViewWithLifecycle { OverlayRoot() }
+        teardownOverlay() // Make sure only one overlay window is active at a time
+        setupOverlay(composeView, layoutParams)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Timber.i("onDestroy()")
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        activeOverlay?.let { windowManager.removeView(it) }
+    }
+
+    override fun onBind(p0: Intent?): IBinder? {
+        return null
+    }
+
+    private fun setupOverlay(view: View, params: WindowManager.LayoutParams) {
+        windowManager.addView(view, params)
+        activeOverlay = view
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
+    }
+
+    private fun teardownOverlay() {
+        activeOverlay?.let { windowManager.removeView(it) }
+        activeOverlay = null
+    }
+
+    private fun createComposeViewWithLifecycle(content: @Composable () -> Unit): ComposeView {
+        val composeView = ComposeView(this)
+        lifecycleOwner.attach()
+        lifecycleOwner.performRestore(null)
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        composeView.setViewTreeLifecycleOwner(lifecycleOwner)
+        composeView.setViewTreeViewModelStoreOwner(OverlayViewModelStoreOwner())
+        composeView.setViewTreeSavedStateRegistryOwner(lifecycleOwner)
+
+        composeView.setContent { content() }
+        return composeView
+    }
+
+    private fun WindowManager.LayoutParams.applyOverlayPositionAsGravity(intent: Intent?) {
+        val overlayPosition =
+            intent?.getStringExtra(OVERLAY_POSITION_EXTRA)?.let { OverlayPosition.valueOf(it) }
+        this.apply {
+            gravity =
+                when (overlayPosition) {
+                    OverlayPosition.BottomLeft -> Gravity.START or Gravity.BOTTOM
+                    OverlayPosition.TopLeft -> Gravity.START or Gravity.TOP
+                    OverlayPosition.BottomRight -> Gravity.END or Gravity.BOTTOM
+                    OverlayPosition.TopRight -> Gravity.END or Gravity.TOP
+                    null -> Gravity.START or Gravity.BOTTOM
+                }
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ZiofaApplication.kt
@@ -10,15 +10,18 @@ import android.content.pm.PackageManager
 import de.amosproj3.ziofa.api.configuration.ConfigurationAccess
 import de.amosproj3.ziofa.api.configuration.SymbolsAccess
 import de.amosproj3.ziofa.api.events.DataStreamProvider
+import de.amosproj3.ziofa.api.overlay.OverlayController
 import de.amosproj3.ziofa.api.processes.RunningComponentsAccess
-import de.amosproj3.ziofa.bl.configuration.ConfigurationManager
-import de.amosproj3.ziofa.bl.configuration.UProbeManager
-import de.amosproj3.ziofa.bl.events.DataStreamManager
-import de.amosproj3.ziofa.bl.processes.PackageInformationProvider
-import de.amosproj3.ziofa.bl.processes.RunningComponentsProvider
 import de.amosproj3.ziofa.client.ClientFactory
 import de.amosproj3.ziofa.client.RustClientFactory
+import de.amosproj3.ziofa.platform.configuration.ConfigurationManager
+import de.amosproj3.ziofa.platform.configuration.UProbeManager
+import de.amosproj3.ziofa.platform.events.DataStreamManager
+import de.amosproj3.ziofa.platform.overlay.OverlayManager
+import de.amosproj3.ziofa.platform.processes.PackageInformationProvider
+import de.amosproj3.ziofa.platform.processes.RunningComponentsProvider
 import de.amosproj3.ziofa.ui.configuration.ConfigurationViewModel
+import de.amosproj3.ziofa.ui.overlay.OverlayViewModel
 import de.amosproj3.ziofa.ui.processes.ProcessesViewModel
 import de.amosproj3.ziofa.ui.reset.ResetViewModel
 import de.amosproj3.ziofa.ui.symbols.SymbolsViewModel
@@ -27,6 +30,7 @@ import kotlinx.coroutines.CoroutineScope
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
+import org.koin.core.logger.Level
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.parameter.parametersOf
@@ -34,13 +38,12 @@ import org.koin.dsl.module
 import timber.log.Timber
 
 class ZiofaApplication : Application() {
-
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree()) // start Timber logging
 
         startKoin {
-            androidLogger()
+            androidLogger(level = Level.DEBUG)
             androidContext(this@ZiofaApplication)
             modules(
                 module {
@@ -65,6 +68,7 @@ class ZiofaApplication : Application() {
         single<ConfigurationAccess> { ConfigurationManager(clientFactory = get()) }
         factory<DataStreamProvider> { (scope: CoroutineScope) -> DataStreamManager(get(), scope) }
         single<SymbolsAccess> { UProbeManager(get()) }
+        single<OverlayController> { OverlayManager(get()) }
     }
 
     private fun Module.createViewModelFactories() {
@@ -78,9 +82,17 @@ class ZiofaApplication : Application() {
                 configurationAccess = get(),
                 runningComponentsAccess = get(),
                 dataStreamProviderFactory = { get { parametersOf(it) } },
+                overlayController = get(),
             )
         }
 
         viewModel { (pids: List<UInt>) -> SymbolsViewModel(get(), get(), pids) }
+
+        viewModel {
+            OverlayViewModel(
+                overlayManager = get(),
+                dataStreamProviderFactory = { get { parametersOf(it) } },
+            )
+        }
     }
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/overlay/OverlayAction.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/overlay/OverlayAction.kt
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.api.overlay
+
+import de.amosproj3.ziofa.ui.visualization.data.OverlaySettings
+import de.amosproj3.ziofa.ui.visualization.data.SelectionData
+
+sealed class OverlayAction {
+    data class ChangeSettings(val newSettings: OverlaySettings) : OverlayAction()
+
+    data class Enable(val selectionData: SelectionData) : OverlayAction()
+
+    data object Disable : OverlayAction()
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/overlay/OverlayController.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/overlay/OverlayController.kt
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.api.overlay
+
+import kotlinx.coroutines.flow.Flow
+
+interface OverlayController {
+    val overlayState: Flow<OverlayState>
+
+    fun dispatchAction(action: OverlayAction)
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/api/overlay/OverlayState.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/api/overlay/OverlayState.kt
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.api.overlay
+
+import de.amosproj3.ziofa.ui.visualization.data.OverlaySettings
+import de.amosproj3.ziofa.ui.visualization.data.SelectionData
+
+sealed class OverlayState(open val overlaySettings: OverlaySettings) {
+    data class Disabled(override val overlaySettings: OverlaySettings) :
+        OverlayState(overlaySettings)
+
+    data class Enabled(
+        override val overlaySettings: OverlaySettings,
+        val selectionData: SelectionData? = null,
+    ) : OverlayState(overlaySettings)
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/platform/configuration/ConfigDiffHelpers.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/platform/configuration/ConfigDiffHelpers.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.bl.configuration
+package de.amosproj3.ziofa.platform.configuration
 
 import de.amosproj3.ziofa.api.configuration.ConfigurationAction
 import de.amosproj3.ziofa.client.Configuration

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/platform/configuration/ConfigurationManager.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/platform/configuration/ConfigurationManager.kt
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.bl.configuration
+package de.amosproj3.ziofa.platform.configuration
 
 import arrow.core.Either
 import com.freeletics.flowredux.dsl.ExecutionPolicy

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/platform/configuration/UProbeManager.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/platform/configuration/UProbeManager.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.bl.configuration
+package de.amosproj3.ziofa.platform.configuration
 
 import de.amosproj3.ziofa.api.configuration.GetSymbolsRequestState
 import de.amosproj3.ziofa.api.configuration.SymbolsAccess

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/platform/events/DataStreamManager.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/platform/events/DataStreamManager.kt
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.bl.events
+package de.amosproj3.ziofa.platform.events
 
 import de.amosproj3.ziofa.api.events.DataStreamProvider
 import de.amosproj3.ziofa.client.ClientFactory

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/platform/overlay/OverlayManager.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/platform/overlay/OverlayManager.kt
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.platform.overlay
+
+import android.content.Context
+import android.content.Intent
+import com.freeletics.flowredux.dsl.FlowReduxStateMachine
+import de.amosproj3.ziofa.OverlayService
+import de.amosproj3.ziofa.api.overlay.OverlayAction
+import de.amosproj3.ziofa.api.overlay.OverlayController
+import de.amosproj3.ziofa.api.overlay.OverlayState
+import de.amosproj3.ziofa.shared.OVERLAY_POSITION_EXTRA
+import de.amosproj3.ziofa.ui.visualization.data.OverlayPosition
+import de.amosproj3.ziofa.ui.visualization.data.OverlaySettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+private val INITIAL_OVERLAY_SETTINGS = OverlaySettings()
+val INITIAL_OVERLAY_STATE = OverlayState.Disabled(INITIAL_OVERLAY_SETTINGS)
+
+/** Communication layer between service and UI */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OverlayManager(private val context: Context) :
+    FlowReduxStateMachine<OverlayState, OverlayAction>(initialState = INITIAL_OVERLAY_STATE),
+    OverlayController {
+
+    override val overlayState = MutableStateFlow<OverlayState>(INITIAL_OVERLAY_STATE)
+
+    override fun dispatchAction(action: OverlayAction) {
+        CoroutineScope(Dispatchers.IO).launch { this@OverlayManager.dispatch(action) }
+    }
+
+    init {
+        initializeStateMachine()
+        startUpdatingState()
+    }
+
+    private fun initializeStateMachine() {
+        spec {
+            inState<OverlayState.Disabled> {
+                onEnter {
+                    stopOverlayService()
+                    it.noChange()
+                }
+                on<OverlayAction.ChangeSettings> { action, state ->
+                    state.mutate { this.copy(overlaySettings = action.newSettings) }
+                }
+                on<OverlayAction.Enable> { action, state ->
+                    state.override {
+                        OverlayState.Enabled(overlaySettings, selectionData = action.selectionData)
+                    }
+                }
+            }
+            inState<OverlayState.Enabled> {
+                onEnter {
+                    startOverlayService(it.snapshot.overlaySettings.selectedPosition)
+                    it.noChange()
+                }
+                on<OverlayAction.ChangeSettings> { action, state ->
+                    state.mutate { copy(overlaySettings = action.newSettings) }
+                }
+                on<OverlayAction.Enable> { action, state ->
+                    state.mutate { copy(selectionData = action.selectionData) }
+                }
+                on<OverlayAction.Disable> { _, state ->
+                    state.override { OverlayState.Disabled(overlaySettings) }
+                }
+            }
+        }
+    }
+
+    private fun startUpdatingState() {
+        CoroutineScope(Dispatchers.IO).launch {
+            this@OverlayManager.state.collect {
+                Timber.i("overlay state updated $it")
+                overlayState.value = it
+            }
+        }
+    }
+
+    private fun startOverlayService(overlayPosition: OverlayPosition) {
+        context.startService(
+            Intent(context, OverlayService::class.java).apply {
+                putExtra(OVERLAY_POSITION_EXTRA, overlayPosition.name)
+            }
+        )
+    }
+
+    private fun stopOverlayService() {
+        context.stopService(Intent(context, OverlayService::class.java))
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/platform/processes/PackageInformationProvider.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/platform/processes/PackageInformationProvider.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.bl.processes
+package de.amosproj3.ziofa.platform.processes
 
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/platform/processes/RunningComponentsProvider.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/platform/processes/RunningComponentsProvider.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.bl.processes
+package de.amosproj3.ziofa.platform.processes
 
 import de.amosproj3.ziofa.api.processes.RunningComponent
 import de.amosproj3.ziofa.api.processes.RunningComponentsAccess

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/shared/Constants.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/shared/Constants.kt
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.shared
+
+const val OVERLAY_POSITION_EXTRA = "OVERLAY_POSITION_EXTRA"

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/ZiofaApp.kt
@@ -95,6 +95,7 @@ fun ZIOFAApp() {
                     },
                 )
             }
+
             parameterizedScreen(
                 "${Routes.IndividualConfiguration.name}?displayName={displayName}?pids={pids}",
                 arguments = listOf(DISPLAY_NAME_ARG, PIDS_ARG),

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayLifecycleOwner.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayLifecycleOwner.kt
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.overlay
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+
+internal class OverlayLifecycleOwner : SavedStateRegistryOwner {
+    private val lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(this)
+    private val savedStateRegistryController = SavedStateRegistryController.create(this)
+    override val savedStateRegistry = savedStateRegistryController.savedStateRegistry
+    override val lifecycle: Lifecycle = lifecycleRegistry
+
+    val isInitialized: Boolean
+        get() = true
+
+    fun setCurrentState(state: Lifecycle.State) {
+        lifecycleRegistry.currentState = state
+    }
+
+    fun attach() {
+        savedStateRegistryController.performAttach()
+    }
+
+    fun handleLifecycleEvent(event: Lifecycle.Event) {
+        lifecycleRegistry.handleLifecycleEvent(event)
+    }
+
+    fun performRestore(savedState: Bundle?) {
+        savedStateRegistryController.performRestore(savedState)
+    }
+
+    fun performSave(outBundle: Bundle) {
+        savedStateRegistryController.performSave(outBundle)
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayRoot.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayRoot.kt
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.overlay
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import de.amosproj3.ziofa.ui.visualization.composables.chart.VicoTimeSeries
+import de.amosproj3.ziofa.ui.visualization.data.GraphedData
+import org.koin.androidx.compose.koinViewModel
+import timber.log.Timber
+
+@Composable
+fun OverlayRoot(viewModel: OverlayViewModel = koinViewModel()) {
+
+    val overlayData by remember(viewModel) { viewModel.overlayData }.collectAsState()
+    val overlaySettings by remember(viewModel) { viewModel.overlaySettings }.collectAsState()
+
+    val data = overlayData // Snapshot
+    val configuration = remember { LocalConfiguration }.current
+    val screenWidth = remember { configuration.screenWidthDp.dp }
+    val screenHeight = remember { configuration.screenHeightDp.dp }
+    Timber.i("$overlayData update in composable")
+
+    Box(
+        modifier =
+            Modifier.size(
+                width = screenWidth * overlaySettings.pctOfScreen,
+                height = screenHeight * overlaySettings.pctOfScreen,
+            )
+    ) {
+        when (data) {
+            is GraphedData.TimeSeriesData -> TimeSeriesOverlay(data)
+            else -> Unsupported(data::class.simpleName.toString())
+        }
+    }
+}
+
+@Composable
+fun Unsupported(visualizationType: String) {
+    Text("Overlay mode unsupported for visualization type $visualizationType")
+}
+
+@Composable
+fun TimeSeriesOverlay(data: GraphedData.TimeSeriesData) {
+    if (data.seriesData.isNotEmpty()) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text("ZIOFA OVERLAY", color = Color.Red)
+            VicoTimeSeries(seriesData = data.seriesData, data.metaData, highContrastMode = true)
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayRoot.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayRoot.kt
@@ -23,7 +23,7 @@ import org.koin.androidx.compose.koinViewModel
 import timber.log.Timber
 
 @Composable
-fun OverlayRoot(viewModel: OverlayViewModel = koinViewModel()) {
+fun OverlayRoot(viewModel: OverlayViewModel = koinViewModel(), modifier: Modifier = Modifier) {
 
     val overlayData by remember(viewModel) { viewModel.overlayData }.collectAsState()
     val overlaySettings by remember(viewModel) { viewModel.overlaySettings }.collectAsState()
@@ -36,7 +36,7 @@ fun OverlayRoot(viewModel: OverlayViewModel = koinViewModel()) {
 
     Box(
         modifier =
-            Modifier.size(
+            modifier.size(
                 width = screenWidth * overlaySettings.pctOfScreen,
                 height = screenHeight * overlaySettings.pctOfScreen,
             )
@@ -49,14 +49,14 @@ fun OverlayRoot(viewModel: OverlayViewModel = koinViewModel()) {
 }
 
 @Composable
-fun Unsupported(visualizationType: String) {
-    Text("Overlay mode unsupported for visualization type $visualizationType")
+fun Unsupported(visualizationType: String, modifier: Modifier = Modifier) {
+    Text("Overlay mode unsupported for visualization type $visualizationType", modifier = modifier)
 }
 
 @Composable
-fun TimeSeriesOverlay(data: GraphedData.TimeSeriesData) {
+fun TimeSeriesOverlay(data: GraphedData.TimeSeriesData, modifier: Modifier = Modifier) {
     if (data.seriesData.isNotEmpty()) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
             Text("ZIOFA OVERLAY", color = Color.Red)
             VicoTimeSeries(seriesData = data.seriesData, data.metaData, highContrastMode = true)
         }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayViewModel.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayViewModel.kt
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.overlay
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import de.amosproj3.ziofa.api.events.DataStreamProvider
+import de.amosproj3.ziofa.api.overlay.OverlayController
+import de.amosproj3.ziofa.api.overlay.OverlayState
+import de.amosproj3.ziofa.ui.visualization.data.GraphedData
+import de.amosproj3.ziofa.ui.visualization.data.OverlaySettings
+import de.amosproj3.ziofa.ui.visualization.getChartData
+import de.amosproj3.ziofa.ui.visualization.utils.DEFAULT_CHART_METADATA
+import de.amosproj3.ziofa.ui.visualization.utils.isValidSelection
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.stateIn
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OverlayViewModel(
+    val overlayManager: OverlayController,
+    val dataStreamProviderFactory: (CoroutineScope) -> DataStreamProvider,
+) : ViewModel() {
+
+    private val dataStreamProvider = dataStreamProviderFactory(viewModelScope)
+
+    val overlaySettings =
+        overlayManager.overlayState
+            .map { it.overlaySettings }
+            .stateIn(viewModelScope, SharingStarted.Lazily, OverlaySettings())
+
+    val overlayData =
+        overlayManager.overlayState
+            .mapNotNull { it as? OverlayState.Enabled }
+            .mapNotNull { it.selectionData }
+            .flatMapLatest {
+                if (isValidSelection(it.selectedMetric, it.selectedTimeframe)) {
+                    dataStreamProvider.getChartData(
+                        it.selectedComponent,
+                        it.selectedMetric,
+                        it.selectedTimeframe,
+                        chartMetadata = DEFAULT_CHART_METADATA,
+                    ) ?: flowOf(GraphedData.EMPTY) // TODO add disclaimer
+                } else flowOf(GraphedData.EMPTY)
+            }
+            .stateIn(viewModelScope, SharingStarted.Lazily, GraphedData.EMPTY)
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayViewModelStoreOwner.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayViewModelStoreOwner.kt
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
-//
-// SPDX-License-Identifier: MIT
-
-package de.amosproj3.ziofa.ui.overlay
-
-class OverlayViewModelStoreOwner {}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayViewModelStoreOwner.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/overlay/OverlayViewModelStoreOwner.kt
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.overlay
+
+class OverlayViewModelStoreOwner {}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/shared/ConfigurationHelpers.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/shared/ConfigurationHelpers.kt
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2024 Luca Bretting <luca.bretting@fau.de>
-//
-// SPDX-License-Identifier: MIT
-
-package de.amosproj3.ziofa.ui.shared

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/chart/VicoTimeSeries.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/chart/VicoTimeSeries.kt
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.chart
 
+import android.graphics.Typeface
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -20,10 +20,10 @@ import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
 import com.patrykandpatrick.vico.compose.cartesian.cartesianLayerPadding
-import com.patrykandpatrick.vico.compose.cartesian.layer.rememberColumnCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLine
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
-import com.patrykandpatrick.vico.compose.common.component.rememberLineComponent
 import com.patrykandpatrick.vico.compose.common.component.rememberShapeComponent
 import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
 import com.patrykandpatrick.vico.compose.common.component.shapeComponent
@@ -32,35 +32,30 @@ import com.patrykandpatrick.vico.compose.common.fill
 import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
 import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
-import com.patrykandpatrick.vico.core.cartesian.data.columnSeries
-import com.patrykandpatrick.vico.core.cartesian.layer.ColumnCartesianLayer
+import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.common.shape.CorneredShape
 import de.amosproj3.ziofa.ui.visualization.data.ChartMetadata
 import de.amosproj3.ziofa.ui.visualization.utils.VICO_LINE_COLOR
+import de.amosproj3.ziofa.ui.visualization.utils.isDefaultSeries
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @Composable
-fun VicoBar(
+fun VicoTimeSeries(
+    seriesData: ImmutableList<Pair<Float, Float>>,
     chartMetadata: ChartMetadata,
-    seriesData: ImmutableList<Pair<ULong, ULong>>,
     modifier: Modifier = Modifier,
+    highContrastMode: Boolean = false, // for overlay
 ) {
-    Column(
-        modifier.padding(10.dp).fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
+    Timber.i("$seriesData")
+    Column(modifier.padding(10.dp), horizontalAlignment = Alignment.CenterHorizontally) {
         val modelProducer = remember { CartesianChartModelProducer() }
-        if (seriesData.isNotEmpty()) {
-            Timber.e("bar data $seriesData")
-            modelProducer.SeriesUpdate(seriesData.map { it.second.toInt() })
-            modelProducer.TimeSeriesChart(
-                chartMetadata = chartMetadata,
-                xLabels = seriesData.map { it.first.toString() }.toImmutableList(),
-            )
+        if (seriesData.isNotEmpty() && !seriesData.isDefaultSeries()) {
+            modelProducer.SeriesUpdate(seriesData)
+            modelProducer.TimeSeriesChart(chartMetadata, highContrastMode)
         }
     }
 }
@@ -68,29 +63,31 @@ fun VicoBar(
 @Composable
 private fun CartesianChartModelProducer.TimeSeriesChart(
     chartMetadata: ChartMetadata,
-    xLabels: ImmutableList<String>,
+    highContrastMode: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val mainColor = remember { if (highContrastMode) Color.Red else Color.Black }
+    val typeface = remember { if (highContrastMode) Typeface.DEFAULT_BOLD else Typeface.DEFAULT }
+    val xLabel = remember { chartMetadata.xLabel }
+    val yLabel = remember { chartMetadata.yLabel }
+
     CartesianChartHost(
         chart =
             rememberCartesianChart(
-                rememberColumnCartesianLayer(
-                    ColumnCartesianLayer.ColumnProvider.series(
-                        xLabels.map { _ ->
-                            rememberLineComponent(
-                                fill = fill(VICO_LINE_COLOR),
-                                shape =
-                                    CorneredShape.rounded(
-                                        bottomLeftPercent = 40,
-                                        bottomRightPercent = 40,
-                                    ),
-                            )
-                        }
+                rememberLineCartesianLayer(
+                    LineCartesianLayer.LineProvider.series(
+                        LineCartesianLayer.rememberLine(
+                            remember {
+                                LineCartesianLayer.LineFill.single(
+                                    fill(if (highContrastMode) mainColor else VICO_LINE_COLOR)
+                                )
+                            }
+                        )
                     )
                 ),
                 startAxis =
                     VerticalAxis.rememberStart(
-                        label = rememberTextComponent(),
+                        label = rememberTextComponent(color = mainColor, typeface = typeface),
                         titleComponent =
                             rememberTextComponent(
                                 color = Color.White,
@@ -102,10 +99,11 @@ private fun CartesianChartModelProducer.TimeSeriesChart(
                                         shape = CorneredShape.Pill,
                                     ),
                             ),
-                        title = chartMetadata.yLabel,
+                        title = yLabel,
                     ),
                 bottomAxis =
                     HorizontalAxis.rememberBottom(
+                        label = rememberTextComponent(color = mainColor, typeface = typeface),
                         titleComponent =
                             rememberTextComponent(
                                 color = Color.White,
@@ -117,13 +115,9 @@ private fun CartesianChartModelProducer.TimeSeriesChart(
                                         shape = CorneredShape.Pill,
                                     ),
                             ),
-                        title = chartMetadata.xLabel,
-                        label = rememberTextComponent(),
+                        title = xLabel,
                         guideline = null,
                         itemPlacer = remember { HorizontalAxis.ItemPlacer.segmented() },
-                        valueFormatter = { _, value, _ ->
-                            xLabels.getOrNull(value.toInt()) ?: "UNKNOWN"
-                        },
                     ),
                 layerPadding = cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp),
             ),
@@ -134,13 +128,11 @@ private fun CartesianChartModelProducer.TimeSeriesChart(
 }
 
 @Composable
-private fun CartesianChartModelProducer.SeriesUpdate(update: List<Int>) {
+private fun CartesianChartModelProducer.SeriesUpdate(update: List<Pair<Float, Float>>) {
     LaunchedEffect(update) {
         withContext(Dispatchers.Default) {
             this@SeriesUpdate.runTransaction {
-                this.extras {}
-                Timber.e(update.toString())
-                columnSeries { series(x = update.indices.toList().reversed(), y = update) }
+                lineSeries { series(update.map { (x, _) -> x }, update.map { (_, y) -> y }) }
             }
         }
     }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/OverlayPositionSelector.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/OverlayPositionSelector.kt
@@ -51,11 +51,7 @@ fun OverlayPositionSelector(
                 trailingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
                 modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
             )
-            ExposedDropdownMenu(
-                modifier = modifier,
-                expanded = expanded,
-                onDismissRequest = { expanded = false },
-            ) {
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                 options.forEach { option ->
                     DropdownMenuItem(
                         text = { Text(option.displayName) },

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/OverlayPositionSelector.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/OverlayPositionSelector.kt
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.visualization.composables.overlay
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import de.amosproj3.ziofa.ui.visualization.data.OverlayPosition
+import kotlinx.collections.immutable.ImmutableList
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OverlayPositionSelector(
+    selectedPosition: OverlayPosition,
+    options: ImmutableList<OverlayPosition>,
+    onPositionSelected: (OverlayPosition) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier.padding(10.dp)) {
+        Text("Overlay Position", fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(10.dp))
+        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+            TextField(
+                value = selectedPosition.displayName,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Select a position for the overlay (requires overlay restart)") },
+                trailingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
+                modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+            )
+            ExposedDropdownMenu(
+                modifier = modifier,
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option.displayName) },
+                        onClick = {
+                            onPositionSelected(option)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/OverlaySizeSlider.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/OverlaySizeSlider.kt
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.visualization.composables.overlay
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun OverlaySizeSlider(
+    overlaySizePct: Float,
+    onOverlaySizeChanged: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var overlaySize by remember { mutableFloatStateOf(overlaySizePct) }
+
+    Column(modifier = modifier.padding(10.dp)) {
+        Text("Overlay Size")
+        Spacer(Modifier.height(10.dp))
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Slider(
+                value = overlaySize,
+                onValueChange = { overlaySize = it },
+                valueRange = 0f..0.99f,
+                onValueChangeFinished = { onOverlaySizeChanged(overlaySize) },
+            )
+            Text(text = "${(overlaySize * 100).toInt()}% of screen")
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/TrafficLightIndicator.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/overlay/TrafficLightIndicator.kt
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.visualization.composables.overlay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/** Fancy status indicator */
+@Composable
+fun TrafficLightIndicator(active: Boolean, modifier: Modifier = Modifier) {
+    val lightShapeModifier = Modifier.size(150.dp).clip(CircleShape).padding(10.dp)
+    Column(modifier.background(Color.DarkGray).clip(CircleShape)) {
+        Box(modifier = lightShapeModifier.background(if (active) Color.Green else Color.LightGray))
+        Box(modifier = lightShapeModifier.background(Color.LightGray))
+        Box(modifier = lightShapeModifier.background(if (!active) Color.Red else Color.LightGray))
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/CenteredInfoText.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/CenteredInfoText.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.selection
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/MetricDropdown.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/MetricDropdown.kt
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.selection
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/MetricSelection.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/MetricSelection.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.selection
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/SelectMetricPrompt.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/SelectMetricPrompt.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.selection
 
 import androidx.compose.runtime.Composable
 

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/SwitchModeFab.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/SwitchModeFab.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.selection
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -69,30 +69,6 @@ fun SwitchModeFab(
 }
 
 @Composable
-private fun MenuItems(
-    onItemClicked: (VisualizationDisplayMode) -> Unit,
-    interactionSource: MutableInteractionSource,
-) {
-    Column(modifier = Modifier.padding(vertical = 20.dp, horizontal = 30.dp)) {
-        listOf(VisualizationDisplayMode.CHART, VisualizationDisplayMode.EVENTS).forEach { item ->
-            Row(
-                modifier =
-                    Modifier.padding(vertical = 10.dp)
-                        .clickable(
-                            interactionSource = interactionSource,
-                            indication = null,
-                            onClick = { onItemClicked(item) },
-                        )
-            ) {
-                Icon(imageVector = item.icon, contentDescription = "")
-                Spacer(modifier = Modifier.width(15.dp))
-                Text(text = item.displayName)
-            }
-        }
-    }
-}
-
-@Composable
 private fun MenuToggle(onClick: () -> Unit, interactionSource: MutableInteractionSource) {
     Card(
         modifier =
@@ -110,5 +86,34 @@ private fun MenuToggle(onClick: () -> Unit, interactionSource: MutableInteractio
                 Text(text = "Select mode")
             }
         }
+    }
+}
+
+@Composable
+private fun MenuItems(
+    onItemClicked: (VisualizationDisplayMode) -> Unit,
+    interactionSource: MutableInteractionSource,
+) {
+    Column(modifier = Modifier.padding(vertical = 20.dp, horizontal = 30.dp)) {
+        listOf(
+                VisualizationDisplayMode.CHART,
+                VisualizationDisplayMode.EVENTS,
+                VisualizationDisplayMode.OVERLAY,
+            )
+            .forEach { item ->
+                Row(
+                    modifier =
+                        Modifier.padding(vertical = 10.dp)
+                            .clickable(
+                                interactionSource = interactionSource,
+                                indication = null,
+                                onClick = { onItemClicked(item) },
+                            )
+                ) {
+                    Icon(imageVector = item.icon, contentDescription = "")
+                    Spacer(modifier = Modifier.width(15.dp))
+                    Text(text = item.displayName)
+                }
+            }
     }
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/ToggleAutoscrollFab.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/ToggleAutoscrollFab.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.selection
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/VisualizationNonExistentPrompt.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/selection/VisualizationNonExistentPrompt.kt
@@ -1,11 +1,14 @@
-// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+package de.amosproj3.ziofa.ui.visualization.composables.selection // SPDX-FileCopyrightText: 2025
+
+// Luca Bretting
+// <luca.bretting@fau.de>
+
 //
 // SPDX-License-Identifier: MIT
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
-import de.amosproj3.ziofa.ui.visualization.composables.CenteredInfoText
 
 @Composable
 fun VisualizationNonExistentPrompt() {

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/ChartViewer.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/ChartViewer.kt
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.visualization.composables.viewers
+
+import androidx.compose.runtime.Composable
+import de.amosproj3.ziofa.ui.visualization.composables.chart.VicoBar
+import de.amosproj3.ziofa.ui.visualization.composables.chart.VicoTimeSeries
+import de.amosproj3.ziofa.ui.visualization.data.GraphedData
+
+@Composable
+fun ChartViewer(data: GraphedData) {
+    when (data) {
+        is GraphedData.TimeSeriesData ->
+            VicoTimeSeries(seriesData = data.seriesData, chartMetadata = data.metaData)
+
+        is GraphedData.HistogramData ->
+            VicoBar(seriesData = data.seriesData, chartMetadata = data.metaData)
+
+        GraphedData.EMPTY -> {}
+        else -> TODO() // crash because we havent implemented the visualization type yet
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/ChartViewer.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/ChartViewer.kt
@@ -4,7 +4,9 @@
 
 package de.amosproj3.ziofa.ui.visualization.composables.viewers
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import de.amosproj3.ziofa.ui.visualization.composables.chart.VicoBar
 import de.amosproj3.ziofa.ui.visualization.composables.chart.VicoTimeSeries
 import de.amosproj3.ziofa.ui.visualization.data.GraphedData
@@ -13,7 +15,11 @@ import de.amosproj3.ziofa.ui.visualization.data.GraphedData
 fun ChartViewer(data: GraphedData) {
     when (data) {
         is GraphedData.TimeSeriesData ->
-            VicoTimeSeries(seriesData = data.seriesData, chartMetadata = data.metaData)
+            VicoTimeSeries(
+                seriesData = data.seriesData,
+                chartMetadata = data.metaData,
+                modifier = Modifier.fillMaxSize(),
+            )
 
         is GraphedData.HistogramData ->
             VicoBar(seriesData = data.seriesData, chartMetadata = data.metaData)

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/EventListViewer.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/EventListViewer.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package de.amosproj3.ziofa.ui.visualization.composables
+package de.amosproj3.ziofa.ui.visualization.composables.viewers
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,9 +12,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import de.amosproj3.ziofa.ui.visualization.data.EventListMetadata
 import de.amosproj3.ziofa.ui.visualization.data.GraphedData

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/OverlayLauncher.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/OverlayLauncher.kt
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.visualization.composables.viewers
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+import de.amosproj3.ziofa.ui.visualization.composables.overlay.OverlayPositionSelector
+import de.amosproj3.ziofa.ui.visualization.composables.overlay.OverlaySizeSlider
+import de.amosproj3.ziofa.ui.visualization.composables.overlay.TrafficLightIndicator
+import de.amosproj3.ziofa.ui.visualization.data.OverlaySettings
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+fun OverlayLauncher(
+    overlaySettings: OverlaySettings,
+    overlayEnabled: Boolean,
+    overlayStatusChanged: (Boolean) -> Unit,
+    overlaySettingsChanged: (OverlaySettings) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier.weight(0.3f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            TrafficLightIndicator(overlayEnabled)
+        }
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                "Overlay Settings",
+                fontSize = TextUnit(30f, TextUnitType.Sp),
+                fontWeight = FontWeight.Bold,
+            )
+
+            OverlayPositionSelector(
+                selectedPosition = overlaySettings.selectedPosition,
+                options = overlaySettings.availablePositions.toImmutableList(),
+                onPositionSelected = {
+                    overlaySettingsChanged(overlaySettings.copy(selectedPosition = it))
+                },
+            )
+
+            Spacer(Modifier.height(10.dp))
+            OverlaySizeSlider(
+                overlaySizePct = overlaySettings.pctOfScreen,
+                onOverlaySizeChanged = {
+                    overlaySettingsChanged(overlaySettings.copy(pctOfScreen = it))
+                },
+            )
+
+            Spacer(Modifier.height(20.dp))
+            Button(
+                onClick = { overlayStatusChanged(!overlayEnabled) },
+                content = {
+                    Text(
+                        text = if (overlayEnabled) "Disable overlay" else "Enable overlay",
+                        fontSize = TextUnit(20f, TextUnitType.Sp),
+                    )
+                },
+            )
+        }
+    }
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/OverlayLauncher.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/composables/viewers/OverlayLauncher.kt
@@ -27,17 +27,22 @@ import de.amosproj3.ziofa.ui.visualization.composables.overlay.TrafficLightIndic
 import de.amosproj3.ziofa.ui.visualization.data.OverlaySettings
 import kotlinx.collections.immutable.toImmutableList
 
+private const val OVERLAY_TITLE_SIZE = 30f
+private const val OVERLAY_BUTTON_SIZE = 20f
+
+@Suppress("MagicNumber") // does not improve readability
 @Composable
 fun OverlayLauncher(
     overlaySettings: OverlaySettings,
     overlayEnabled: Boolean,
     overlayStatusChanged: (Boolean) -> Unit,
     overlaySettingsChanged: (OverlaySettings) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
     ) {
         Column(
             modifier = Modifier.weight(0.3f),
@@ -52,7 +57,7 @@ fun OverlayLauncher(
         ) {
             Text(
                 "Overlay Settings",
-                fontSize = TextUnit(30f, TextUnitType.Sp),
+                fontSize = TextUnit(OVERLAY_TITLE_SIZE, TextUnitType.Sp),
                 fontWeight = FontWeight.Bold,
             )
 
@@ -78,7 +83,7 @@ fun OverlayLauncher(
                 content = {
                     Text(
                         text = if (overlayEnabled) "Disable overlay" else "Enable overlay",
-                        fontSize = TextUnit(20f, TextUnitType.Sp),
+                        fontSize = TextUnit(OVERLAY_BUTTON_SIZE, TextUnitType.Sp),
                     )
                 },
             )

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/OverlaySettings.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/OverlaySettings.kt
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.visualization.data
+
+enum class OverlayPosition(val displayName: String) {
+    TopLeft("Top Left"),
+    TopRight("Top Right"),
+    BottomLeft("Bottom Left"),
+    BottomRight("Bottom Right"),
+}
+
+private val DEFAULT_AVAILABLE_POSITIONS =
+    listOf(
+        OverlayPosition.TopLeft,
+        OverlayPosition.TopRight,
+        OverlayPosition.BottomLeft,
+        OverlayPosition.BottomRight,
+    )
+
+private val DEFAULT_OVERLAY_POSITION = OverlayPosition.BottomLeft
+
+data class OverlaySettings(
+    val selectedPosition: OverlayPosition = DEFAULT_OVERLAY_POSITION,
+    val availablePositions: List<OverlayPosition> = DEFAULT_AVAILABLE_POSITIONS,
+    val pctOfScreen: Float = 0.3f,
+)

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/VisualizationAction.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/VisualizationAction.kt
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Luca Bretting <luca.bretting@fau.de>
+//
+// SPDX-License-Identifier: MIT
+
+package de.amosproj3.ziofa.ui.visualization.data
+
+/** Interactions with the UI lead to these actions that are processed by the view model. */
+sealed class VisualizationAction {
+
+    /**
+     * An option in a dropdown has changed, which one is determined by the [DropdownOption]
+     * subclass.
+     */
+    data class OptionChanged(val option: DropdownOption) : VisualizationAction()
+
+    /** The visualization display mode has changed. */
+    data class ModeChanged(val newMode: VisualizationDisplayMode) : VisualizationAction()
+
+    /** The overlay has been activated or deactivated by the user. */
+    data class OverlayStatusChanged(val newState: Boolean) : VisualizationAction()
+
+    /** The overlays settings were changed by the user. */
+    data class OverlaySettingsChanged(val newSettings: OverlaySettings) : VisualizationAction()
+}

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/VisualizationDisplayMode.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/VisualizationDisplayMode.kt
@@ -7,9 +7,11 @@ package de.amosproj3.ziofa.ui.visualization.data
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class VisualizationDisplayMode(val displayName: String, val icon: ImageVector) {
     CHART("Chart", Icons.Filled.PlayArrow),
     EVENTS("Event list", Icons.AutoMirrored.Filled.List),
+    OVERLAY("Overlay", Icons.Filled.Star),
 }

--- a/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/VisualizationScreenState.kt
+++ b/frontend/app/src/main/java/de/amosproj3/ziofa/ui/visualization/data/VisualizationScreenState.kt
@@ -22,6 +22,13 @@ sealed class VisualizationScreenState {
             override val selectionData: SelectionData,
             val eventListMetadata: EventListMetadata,
         ) : Valid(selectionData)
+
+        /** Screen displays the overlay launcher. */
+        data class OverlayView(
+            override val selectionData: SelectionData,
+            val overlaySettings: OverlaySettings,
+            val overlayEnabled: Boolean,
+        ) : Valid(selectionData)
     }
 
     /** States that are not errors, but are waiting for a valid selection. */

--- a/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
+++ b/frontend/client/src/mock/java/de/amosproj3/ziofa/client/RustClient.kt
@@ -17,10 +17,10 @@ const val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 object RustClient : Client {
     private var configuration: Configuration =
         Configuration(
-            vfsWrite = VfsWriteConfig(mapOf(1234u to 30000u, 43124u to 20000u)),
+            vfsWrite = VfsWriteConfig(mapOf(1u to 1u, 43124u to 20000u)),
             sysSendmsg = SysSendmsgConfig(mapOf(1234u to 30000u, 43124u to 20000u)),
             uprobes = listOf(),
-            jniReferences = JniReferencesConfig(pids = listOf()),
+            jniReferences = JniReferencesConfig(pids = listOf(1u)),
             sysSigquit = SysSigquitConfig(pids = listOf()),
             gc = GcConfig,
             sysFdTracking = SysFdTrackingConfig(pids = listOf()),
@@ -64,14 +64,16 @@ object RustClient : Client {
     }
 
     private val processes =
-        alphabet.indices.map {
-            Process(
-                pid = Random.nextUInt(1000u),
-                ppid = Random.nextUInt(1000u),
-                state = "R",
-                cmd = Command.Comm("/bin/sh/${alphabet.substring(it, it + 1)}"),
-            )
-        }
+        alphabet.indices
+            .map {
+                Process(
+                    pid = Random.nextUInt(1000u),
+                    ppid = Random.nextUInt(1000u),
+                    state = "R",
+                    cmd = Command.Comm("/bin/sh/${alphabet.substring(it, it + 1)}"),
+                )
+            }
+            .plus(Process(pid = 1u, ppid = 1u, state = "R", cmd = Command.Comm("/bin/ziofatest")))
 
     override suspend fun listProcesses(): List<Process> {
         return processes
@@ -87,7 +89,7 @@ object RustClient : Client {
 
     override suspend fun initStream(): Flow<Event> = flow {
         while (true) {
-            delay(Random.nextUInt(500u).toLong())
+            delay(Random.nextUInt(2000u).toLong())
 
             configuration.vfsWrite?.entries?.keys?.forEach {
                 emit(


### PR DESCRIPTION
This PR 
- adds the overlay mode
- adds overlay launcher to visualization
- renames bl package to platform
- reuses the existing visualizations with Vico with changed color 

Limitations:
- currently only for timeseries data
- OverlayService can be killed on low memory -> should use foreground service and persistent notification
- background color/ transparency not changable -> should be an option
- time series length should ideally be scaled with the overlay

[overlay_proto_4.webm](https://github.com/user-attachments/assets/538d4202-7237-4a86-9148-cc72297cef89)

Closes: #178 